### PR TITLE
Fix WIN32s build

### DIFF
--- a/ConfigManager.cpp
+++ b/ConfigManager.cpp
@@ -20,7 +20,7 @@ void SetFontSize(LOGFONT *font, HDC hDC, int fsiz, int fx)
 	if(!hDC) ::ReleaseDC( NULL, h ); // release if captured!
 }
 
-void VConfig::SetFont( const TCHAR* fnam, int fsiz, char fontCS, LONG fw, BYTE ff, int fx, int qual )
+void VConfig::SetFont( const TCHAR* fnam, int fsiz, uchar fontCS, LONG fw, BYTE ff, int fx, int qual )
 {
 	fontsize              = fsiz;
 	fontwidth             = fx;
@@ -756,11 +756,7 @@ void ConfigManager::LoadIni()
 	grepExe_   = ini_.GetStr( TEXT("GrepExe"), TEXT("") );
 	openSame_  = ini_.GetBool( TEXT("OpenSame"), false );
 	countbyunicode_ = ini_.GetBool( TEXT("CountUni"), false );
-#if defined(TARGET_VER) && TARGET_VER==300
-	showStatusBar_ = false;
-#else
 	showStatusBar_ = ini_.GetBool( TEXT("StatusBar"), true );
-#endif
 
 	dateFormat_   = ini_.GetStr( TEXT("DateFormat"), TEXT("HH:mm yyyy/MM/dd") );
 

--- a/ConfigManager.h
+++ b/ConfigManager.h
@@ -157,8 +157,8 @@ private:
 		int               wrapType;
 		int               wrapWidth;
 		bool              showLN;
-		char              fontCS;
-		int               fontQual;
+		uchar             fontCS;
+		uchar             fontQual;
 	};
 	typedef ki::olist<DocType> DtList;
 

--- a/GpMain.cpp
+++ b/GpMain.cpp
@@ -26,7 +26,7 @@ void BootNewProcess( const TCHAR* cmd = TEXT("") )
 	fcmd += app().isNewTypeWindows()? TEXT("\" "): TEXT(" ");
 	fcmd += TEXT(" ");
 	fcmd += cmd;
-//	MessageBox(hwnd(), (TCHAR*)fcmd.c_str(), (TCHAR*)Path(Path::ExeName).c_str(), MB_OK);
+//	MsgBox((TCHAR*)fcmd.c_str(), (TCHAR*)Path(Path::ExeName).c_str(), MB_OK);
 
 	if( ::CreateProcess( NULL, (TCHAR*)fcmd.c_str(),
 			NULL, NULL, FALSE, NORMAL_PRIORITY_CLASS, NULL, NULL,
@@ -70,23 +70,11 @@ int GpStBar::AutoResize( bool maximized )
 
 	HDC dc = ::GetDC( hwnd() );
 	SIZE s;
+	if( ::GetTextExtentPoint( dc, TEXT("BBBBM"), 5, &s ) ) // Line Ending
+		w[1] = w[2] - s.cx;
+	if( ::GetTextExtentPoint( dc, TEXT("BBBWWWW"), 7, &s ) ) // Charset
+		w[0] = w[1] - s.cx;
 
-#if defined(TARGET_VER) && TARGET_VER <= 300 // Win32s
-	if( App::isWin32s() )
-	{
-		if( ::GetTextExtentPoint( dc, TEXT("BBBBM"), 5, &s ) ) // Line Ending
-			w[1] = w[2] - s.cx;
-		if( ::GetTextExtentPoint( dc, TEXT("BBBWWWW"), 7, &s ) ) // Charset
-			w[0] = w[1] - s.cx;
-	}
-	else
-#endif
-	{
-		if( ::GetTextExtentPoint32( dc, TEXT("BBBBM"), 5, &s ) ) // Line Ending
-			w[1] = w[2] - s.cx;
-		if( ::GetTextExtentPoint32( dc, TEXT("BBBWWWW"), 7, &s ) ) // Charset
-			w[0] = w[1] - s.cx;
-	}
 	::ReleaseDC( hwnd(), dc );
 
 	SetParts( countof(w), w );
@@ -388,7 +376,7 @@ void GreenPadWnd::on_pagesetup()
 	}
 	else
 	{
-		MessageBox(hwnd(), TEXT("You need at least Windows NT 3.51!\n"), NULL, MB_OK);
+		MsgBox(TEXT("You need at least Windows NT 3.51!\n"), NULL, MB_OK);
 	}
 #endif
 }
@@ -434,7 +422,7 @@ void GreenPadWnd::on_print()
 	{
 		TCHAR tmp[128];
 		::wsprintf(tmp,TEXT("StartDoc Error #%d - please check printer."),::GetLastError());
-		::MessageBox( hwnd(), tmp, String(IDS_APPNAME).c_str(), MB_OK|MB_TASKMODAL );
+		MsgBox(tmp, String(IDS_APPNAME).c_str(), MB_OK|MB_TASKMODAL );
 		return;
 		// Handle the error intelligently
 	}
@@ -606,13 +594,8 @@ void GreenPadWnd::on_initmenu( HMENU menu, bool editmenu_only )
 	::CheckMenuItem( menu, ID_CMD_NOWRAP, MF_BYCOMMAND|(wrap_==-1?MF_CHECKED:MF_UNCHECKED));
 	::CheckMenuItem( menu, ID_CMD_WRAPWIDTH, MF_BYCOMMAND|(wrap_>0?MF_CHECKED:MF_UNCHECKED));
 	::CheckMenuItem( menu, ID_CMD_WRAPWINDOW, MF_BYCOMMAND|(wrap_==0?MF_CHECKED:MF_UNCHECKED));
+	::CheckMenuItem( menu, ID_CMD_STATUSBAR, cfg_.showStatusBar()?MF_CHECKED:MF_UNCHECKED );
 
-#if defined(TARGET_VER) && TARGET_VER==300
-	::EnableMenuItem( menu, ID_CMD_STATUSBAR, MF_BYCOMMAND|MF_GRAYED );
-#else
-	::CheckMenuItem( menu, ID_CMD_STATUSBAR,
-		cfg_.showStatusBar()?MF_CHECKED:MF_UNCHECKED );
-#endif
 	LOGGER("GreenPadWnd::ReloadConfig on_initmenu end");
 }
 
@@ -1069,7 +1052,7 @@ BOOL GreenPadWnd::SendMsgToAllFriends(UINT msg)
 }
 bool GreenPadWnd::OpenByMyself( const ki::Path& fn, int cs, bool needReConf, bool always )
 {
-//	MessageBox(hwnd(), fn.c_str(), TEXT("File"), 0);
+//	MsgBox(fn.c_str(), TEXT("File"), 0);
 	// ファイルを開けなかったらそこでおしまい。
 	aptr<TextFileR> tf( new TextFileR(cs) );
 
@@ -1262,11 +1245,7 @@ void GreenPadWnd::on_create( CREATESTRUCT* cs )
 	LOGGER("GreenPadWnd::on_create edit created");
 	edit_.getDoc().AddHandler( this );
 	edit_.getCursor().AddHandler( this );
-#if !defined(TARGET_VER) || (defined(TARGET_VER) && TARGET_VER>300)
 	stb_.SetStatusBarVisible( cfg_.showStatusBar() );
-#elif defined(TARGET_VER) && TARGET_VER==300
-	stb_.SetStatusBarVisible( false );
-#endif
 
 	LOGGER("GreenPadWnd::on_create halfway");
 
@@ -1315,7 +1294,7 @@ void GreenPadWnd::ShowUp2()
 
 int kmain()
 {
-	// MessageBox(hwnd(), GetCommandLine(), TEXT("Command Line"), MB_OK);
+	// MsgBox(GetCommandLine(), TEXT("Command Line"), MB_OK);
 	LOGGER( "kmain() begin" );
 
 	Argv  arg;

--- a/OpenSaveDlg.cpp
+++ b/OpenSaveDlg.cpp
@@ -322,7 +322,7 @@ bool OpenFileDlg::DoModal( HWND wnd, const TCHAR* fltr, const TCHAR* fnm )
 		} else {
 			TCHAR tmp[128];
 			::wsprintf(tmp,TEXT("GetOpenFileName Error #%d."),ErrCode);
-			::MessageBox( wnd, tmp, String(IDS_APPNAME).c_str(), MB_OK|MB_TASKMODAL );
+			MessageBox( wnd, tmp, String(IDS_APPNAME).c_str(), MB_OK );
 		}
 	}
 	return ( ret != 0 );
@@ -455,7 +455,7 @@ bool SaveFileDlg::DoModal( HWND wnd, const TCHAR* fltr, const TCHAR* fnm )
 		} else {
 			TCHAR tmp[128];
 			::wsprintf(tmp,TEXT("GetSaveFileName Error #%d."),ErrCode);
-			::MessageBox( wnd, tmp, String(IDS_APPNAME).c_str(), MB_OK|MB_TASKMODAL );
+			::MessageBox( wnd, tmp, String(IDS_APPNAME).c_str(), MB_OK );
 		}
 	}
 	return ( ret != 0 );

--- a/Search.cpp
+++ b/Search.cpp
@@ -326,7 +326,7 @@ void SearchManager::NotFound(bool GoingDown)
 			FindNextImpl(true);
 		}
 	} else {
-	    ::MessageBox(hwnd(), String(IDS_NOTFOUND).c_str(), NULL, MB_OK|MB_TASKMODAL);
+	    MsgBox(String(IDS_NOTFOUND).c_str(), NULL, MB_OK|MB_TASKMODAL);
 	}
 }
 

--- a/editwing/ewCommon.h
+++ b/editwing/ewCommon.h
@@ -181,7 +181,7 @@ struct VConfig : public ki::Object
 		SetFont( fnam,fsiz,fontCS,DEFAULT_QUALITY );
 	}*/
 	void SetFont( const TCHAR* fnam, int fsiz
-				, char fontCS=DEFAULT_CHARSET
+				, uchar fontCS=DEFAULT_CHARSET
 				, LONG fw=FW_DONTCARE, BYTE ff=0, int fx=0
 				, int qual=DEFAULT_QUALITY ) ;
 /*	{

--- a/editwing/ip_cursor.cpp
+++ b/editwing/ip_cursor.cpp
@@ -578,7 +578,7 @@ void Cursor::Copy()
 		// NT系ならそのままダイレクトに, Direct copy
 		h = ::GlobalAlloc( GMEM_MOVEABLE, (len+1)*2 );
 		if (!h) {
-			MessageBox(NULL, TEXT("Selection is too large to hold into memory!"), NULL, MB_OK|MB_TASKMODAL) ;
+			MessageBox(NULL, TEXT("Selection is too large to hold into memory!"), NULL, MB_OK|MB_TASKMODAL|MB_TOPMOST) ;
 			return;
 		}
 		doc_.getText( static_cast<unicode*>(::GlobalLock(h)), dm, dM );
@@ -590,7 +590,7 @@ void Cursor::Copy()
 		// 9x系なら変換が必要, convert to ANSI before.
 		h = ::GlobalAlloc( GMEM_MOVEABLE, (len+1)*3 );
 		if (!h) {
-			MessageBox(NULL, TEXT("Selection is too large to hold into memory!"), NULL, MB_OK|MB_TASKMODAL) ;
+			MessageBox(NULL, TEXT("Selection is too large to hold into memory!"), NULL, MB_OK|MB_TASKMODAL|MB_TOPMOST) ;
 			return;
 		}
 		p = new unicode[len+1];
@@ -802,6 +802,7 @@ void Cursor::End( bool wide, bool select )
 void Cursor::Ud( int dy, bool select )
 {
 	// はみ出す場合は、先頭行/終端行で止まるように制限
+	// Limit overflow to stop at start/end line
 	VPos np = cur_;
 	if( (signed)np.vl + dy < 0 )
 		dy = -(signed)np.vl;
@@ -810,7 +811,7 @@ void Cursor::Ud( int dy, bool select )
 
 	np.vl += dy;
 	np.rl += dy;
-	if( dy<0 ) // 上へ戻る場合
+	if( dy<0 ) // 上へ戻る場合, To go back to the top
 	{
 		// ジャンプ先論理行の行頭へDash!
 		while( (signed)np.rl < 0 )
@@ -825,10 +826,10 @@ void Cursor::Ud( int dy, bool select )
 			np.rl += view_.rln(--np.tl); //行き過ぎ修正～
 	}
 
-	// x座標決定にかかる
+	// x座標決定にかかる, x-coordinate determination
 	const unicode* str = doc_.tl(np.tl);
 
-	// 右寄せになってる。不自然？
+	// 右寄せになってる。不自然？, It's right-justified. Unnatural?
 	np.ad = (np.rl==0 ? 0 : view_.rlend(np.tl,np.rl-1)+1);
 	np.vx = (np.rl==0 ? 0 : view_.fnt().W(&str[np.ad-1]));
 	while( np.vx < np.rx && np.ad < view_.rlend(np.tl,np.rl) )

--- a/editwing/ip_parse.cpp
+++ b/editwing/ip_parse.cpp
@@ -29,16 +29,16 @@ using namespace editwing::doc;
 // -----------------------------------------------
 //
 // Line::isLineHeadCommented_
-//    0: 行頭がブロックコメントの内部ではない
-//    1: 行頭がブロックコメントの内部
+//    0: 行頭がブロックコメントの内部ではない, The beginning of the line is not inside the block comment
+//    1: 行頭がブロックコメントの内部,
 //
 // -----------------------------------------------
 //
 // Line::commentTransition_
-//   00: 行末は常にコメントの外
-//   01: 行頭と行末はコメント状態が逆転
-//   10: 行頭と行末はコメント状態が同じ
-//   11: 行末は常にコメントの中
+//   00: 行末は常にコメントの外, End of line always out of comment
+//   01: 行頭と行末はコメント状態が逆転, Comment state is reversed at the beginning of a line and at the end of a line
+//   10: 行頭と行末はコメント状態が同じ, Comment state is the same at the beginning of a line and at the end of a line
+//   11: 行末は常にコメントの中, The end of the line is always in the comment
 //
 // -----------------------------------------------
 //
@@ -53,6 +53,7 @@ using namespace editwing::doc;
 //
 // Line::commentBitReady_
 //   コメントビットが調整済みかどうか
+//   Whether the comment bits have been adjusted or not
 //
 // -----------------------------------------------
 //
@@ -60,43 +61,47 @@ using namespace editwing::doc;
 //   UCS-2ベタで、文字列データがそのまま格納される。
 //   ただし、パーサの高速化のために最終文字の後ろに
 //   0x007fが付加される。
+//   UCS-2 solid, string data is stored as is.
+//   However, to speed up the parser, the last character is followed by
+//   0x007f is appended.
 //
 // -----------------------------------------------
 //
 // Line::flg_
 //   一文字毎に、下のような8bitのフラグを割り当てる
+//   Assign an 8-bit flag as shown below for each character
 //   | aaabbbcd |
 //
 // -----------------------------------------------
 //
 // aaa == "PosInToken"
-//     0: トークンの途中
-//   1-6: トークンの頭。次の頭は1-6文字先。
-//     7: トークンの頭。次の頭は7文字以上先。
+//     0: トークンの途中, Token on the way
+//   1-6: トークンの頭。次の頭は1-6文字先。, Token head. The next head is 1-6 characters ahead.
+//     7: トークンの頭。次の頭は7文字以上先。, Token head. The next head is at least 7 characters ahead.
 //
 // -----------------------------------------------
 //
 // bbb == "TokenType"
-//     0: TAB: タブ文字
-//     1: WSP: ホワイトスペース
-//     2: TXT: 普通の文字
-//     3:  CE: コメント開始タグ
-//     4:  CB: コメント終了タグ
-//     5:  LB: 行コメント開始タグ
-//     6:  Q1: '' 引用符1
-//     7:  Q2: "" 引用符2
+//     0: TAB: タブ文字, tab cahar
+//     1: WSP: ホワイトスペース, white space char
+//     2: TXT: 普通の文字, normal text
+//     3:  CE: コメント開始タグ, comment-start tag
+//     4:  CB: コメント終了タグ, end-of-comment tag
+//     5:  LB: 行コメント開始タグ, line comment start tag
+//     6:  Q1: '' 引用符1, Sinlge Quote
+//     7:  Q2: "" 引用符2, Double Quote
 //
 // -----------------------------------------------
 //
 //  c  == "isKeyword?"
-//     0: キーワードではない
-//     1: キーワード
+//     0: キーワードではない, Not a keyword.
+//     1: キーワード, Keyword
 //
 // -----------------------------------------------
 //
 //  d  == "inComment?"
-//     0: コメントの中ではない
-//     1: コメントの中
+//     0: コメントの中ではない, not in a comment
+//     1: コメントの中, in a comment
 //
 // -----------------------------------------------
 
@@ -211,6 +216,8 @@ static bool compare_i(const unicode* a,const unicode* b,ulong l)
 //-------------------------------------------------------------------------
 // 与えられた記号文字列から、コメント開始等の意味のあるトークンを
 // 切り出してくるための構造。
+// meaningful tokens from a given symbol string, such as the start of a comment.
+// Structure to cut out.
 //-------------------------------------------------------------------------
 
 class TagMap

--- a/editwing/ip_view.h
+++ b/editwing/ip_view.h
@@ -32,45 +32,45 @@ public:
 
 	~Painter();
 
-	//@{ 指定位置に一文字出力 //@}
+	//@{ 指定位置に一文字出力, Output a single character at the specified position //@}
 	void CharOut( unicode ch, int x, int y );
 
-	//@{ 指定位置に文字列を出力 //@}
+	//@{ 指定位置に文字列を出力, Output a string at the specified position //@}
 	void StringOut( const unicode* str, int len, int x, int y );
 
-	//@{ 文字色切り替え //@}
+	//@{ 文字色切り替え, text color switching //@}
 	void SetColor( int i );
 
-	//@{ 背景色で塗りつぶし //@}
+	//@{ 背景色で塗りつぶし, Fill rect with background color //@}
 	void Fill( const RECT& rc );
 
-	//@{ 反転 //@}
+	//@{ 反転, Invert color in the rectangle //@}
 	void Invert( const RECT& rc );
 
-	//@{ 線を引く //@}
+	//@{ 線を引く, Draw a line from point x to point y //@}
 	void DrawLine( int x1, int y1, int x2, int y2 );
 
-	//@{ クリップ領域設定 //@}
+	//@{ クリップ領域設定, (IntersectClipRect())  //@}
 	void SetClip( const RECT& rc );
 
-	//@{ クリップ領域解除 //@}
+	//@{ クリップ領域解除, SelectClipRgn( dc_, NULL)//@}
 	void ClearClip();
 
-	//@{ 半角スペース用記号描画 //@}
+	//@{ 半角スペース用記号描画, Symbol drawing for half-width space //@}
 	void DrawHSP( int x, int y, int times );
 
-	//@{ 全角スペース用記号描画 //@}
+	//@{ 全角スペース用記号描画, Symbol drawing for full-width spaces //@}
 	void DrawZSP( int x, int y, int times );
 
 public:
 
-	//@{ 高さ(pixel) //@}
+	//@{ 高さ, height(pixel) //@}
 	int H() const { return height_; }
 
-	//@{ 数字幅(pixel) //@}
+	//@{ 数字幅, digit width (pixel) //@}
 	int F() const { return figWidth_; }
 
-	//@{ 文字幅(pixel) //@}
+	//@{ 文字幅, character width (pixel) //@}
 	int Wc( unicode ch ) const
 		{
 			if( widthTable_[ ch ] == -1 )
@@ -89,7 +89,7 @@ public:
 #endif
 			return widthTable_[ ch ];
 		}
-	int W( const unicode* pch ) const // 1.08 サロゲートペア回避
+	int W( const unicode* pch ) const // 1.08 サロゲートペア回避, Avoid Surrogate Pair
 		{
 			unicode ch = *pch;
 			if( widthTable_[ ch ] == -1 )
@@ -115,6 +115,13 @@ public:
 #endif
 					return w;
 				}
+//				else if ((0x0900 <= ch &&  ch <= 0x097F))
+//				{ // TOO SLOW AND NOT GOOD ENOUGH
+//					SIZE sz1, sz2;
+//					if( ::GetTextExtentPoint32W( dc_, pch, 2, &sz1 ) 
+//					&&  ::GetTextExtentPoint32W( dc_, pch+1, 1, &sz2 ) )
+//						return sz1.cx-sz2.cx;
+//				}
 #ifdef WIN32S
 				if(ch > 0x100)
 				{
@@ -132,18 +139,18 @@ public:
 			return widthTable_[ ch ];
 		}
 
-	//@{ 標準文字幅(pixel) //@}
+	//@{ 標準文字幅, standard character width (pixel) //@}
 	int W() const { return widthTable_[ L'x' ]; }
 
-	//@{ 次のタブ揃え位置を計算 //@}
+	//@{ 次のタブ揃え位置を計算, Calculate next tab alignment position //@}
 	//int nextTab(int x) const { int t=T(); return (x/t+1)*t; }
 	int nextTab(int x) const { int t=T(); return ((x+4)/t+1)*t; }
 	private: int T() const { return widthTable_[ L'\t' ]; } public:
 
-	//@{ 現在のフォント情報 //@}
+	//@{ 現在のフォント情報, Current font information //@}
 	const LOGFONT& LogFont() const { return logfont_; }
 
-	//@{ 特別文字を描画するか否か //@}
+	//@{ 特別文字を描画するか否か, Whether to draw special characters or not //@}
 	bool sc( int i ) const { return scDraw_[i]; }
 
 private:
@@ -153,7 +160,7 @@ private:
 	const HPEN   pen_;
 	const HBRUSH brush_;
 	int          height_;
-	int*         widthTable_;
+	int*         widthTable_; // 65536 values => 256KB
 	int          figWidth_;
 	LOGFONT      logfont_;
 	COLORREF     colorTable_[7];

--- a/kilib.dsp
+++ b/kilib.dsp
@@ -114,7 +114,7 @@ BSC32=bscmake.exe
 LINK32=link.exe
 # ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib comctl32.lib imm32.lib /nologo /subsystem:windows /map /machine:I386 /nodefaultlib /out:"release/GreenPad.exe"
 # SUBTRACT BASE LINK32 /pdb:none
-# ADD LINK32 unicows.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib uuid.lib odbc32.lib odbccp32.lib comctl32.lib imm32.lib delayimp.lib /nologo /subsystem:windows /pdb:none /map /machine:I386 /nodefaultlib /out:"release/GreenPad.exe" /filealign:512 /OPT:REF /OPT:ICF,7 /LARGEADDRESSAWARE
+# ADD LINK32 unicows.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib uuid.lib odbc32.lib odbccp32.lib comctl32.lib imm32.lib delayimp.lib /nologo /subsystem:windows /pdb:none /map /machine:I386 /nodefaultlib /out:"release/GreenPad.exe" /filealign:512 /OPT:REF /OPT:ICF,20 /LARGEADDRESSAWARE
 
 !ELSEIF  "$(CFG)" == "kilib - Win32 NT31 Unicode Release"
 
@@ -165,14 +165,14 @@ LINK32=link.exe
 # ADD BASE MTL /nologo /D "NDEBUG" /mktyplib203 /win32
 # ADD MTL /nologo /D "NDEBUG" /mktyplib203 /win32
 # ADD BASE RSC /l 0x411 /d "NDEBUG"
-# ADD RSC /l 0x411 /d "NDEBUG"
+# ADD RSC /l 0x409 /d "NDEBUG" /d TARGET_VER=300
 BSC32=bscmake.exe
 # ADD BASE BSC32 /nologo
 # ADD BSC32 /nologo
 LINK32=link.exe
 # ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib comctl32.lib imm32.lib /nologo /subsystem:windows /map /machine:I386 /nodefaultlib /out:"release/GreenPad.exe"
 # SUBTRACT BASE LINK32 /pdb:none
-# ADD LINK32 ole32.lib oleaut32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib uuid.lib odbc32.lib odbccp32.lib comctl32.lib imm32.lib delayimp.lib /nologo /subsystem:windows /map /machine:I386 /nodefaultlib /out:"release/GPad32s.exe" /SUBSYSTEM:WINDOWS,3.10 /FIXED:NO /filealign:512 /OPT:REF /OPT:ICF,7
+# ADD LINK32 ole32.lib oleaut32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib uuid.lib odbc32.lib odbccp32.lib comctl32.lib /nologo /subsystem:windows /map /machine:I386 /nodefaultlib /out:"release/GPad32s.exe" /SUBSYSTEM:WINDOWS,3.10 /FIXED:NO /filealign:512 /OPT:REF /OPT:ICF,7
 # SUBTRACT LINK32 /pdb:none
 
 !ELSEIF  "$(CFG)" == "kilib - Win32 Win4_Unicode release"

--- a/kilib/app.cpp
+++ b/kilib/app.cpp
@@ -289,7 +289,7 @@ namespace ki
 	extern "C" void __deregister_frame_info() {};
 	extern "C" void __register_frame_info() {};
 	extern int __stack_chk_guard = 696115047 ;
-	extern "C" int __stack_chk_fail(){ MessageBoxA(NULL, "__stack_chk_fail", NULL, 0) ; ExitProcess(1); };
+	extern "C" int __stack_chk_fail(){ MessageBoxA(NULL, "__stack_chk_fail", NULL, MB_OK|MB_TOPMOST) ; ExitProcess(1); };
 #endif
 
 #ifdef SUPERTINY

--- a/kilib/file.cpp
+++ b/kilib/file.cpp
@@ -263,7 +263,7 @@ void FileW::Write( const void* dat, ulong siz )
 	bPos_ += siz;
 }
 
-void FileW::WriteC( uchar ch )
+void FileW::WriteC( const uchar ch )
 {
 	if( (BUFSIZE-bPos_) <= 1 )
 		Flush();

--- a/kilib/file.h
+++ b/kilib/file.h
@@ -94,7 +94,7 @@ public:
 	void Write( const void* buf, ulong siz );
 
 	//@{ ˆê•¶š‘‚­ //@}
-	void WriteC( uchar ch );
+	void WriteC( const uchar ch );
 
 public:
 


### PR DESCRIPTION
I now got a WORKING Win32s environment on top of Windows 3.11 FWG
1) The GetTextExtentPoint32 is overkill in the status-bar even for NT/9x.
2) StatusBar can be used on Win32s, no problems.
3) Be sure not to load IMM32.DLL on Win32s, you get a message box on Win32s when a DLL cannot be loaded using `LoadLibrary()`
