### PR TITLE
Increade bufer size for reading file

### DIFF
--- a/editwing/ip_doc.h
+++ b/editwing/ip_doc.h
@@ -62,7 +62,7 @@ public:
 			{
 				// バッファ拡張
 				ulong psiz = (alen_+1)*2+alen_;
-				alen_ = Max( alen_<<1, len_+siz );
+				alen_ = len_+siz; // Max( alen_<<1, len_+siz );
 				unicode* tmpS =
 					static_cast<unicode*>( mem().Alloc((alen_+1)*2+alen_) );
 				uchar*   tmpF =

--- a/editwing/ip_text.cpp
+++ b/editwing/ip_text.cpp
@@ -732,7 +732,13 @@ void DocImpl::OpenFile( aptr<TextFileR> tf )
 	// ‘}“ü, Insertion
 	DPos e(0,0);
 
-	unicode buf[1024];
+	// unicode buf[1024];
+	// Use big buffer (much faster on long lines)
+#ifdef WIN64
+	static unicode buf[2097152]; // 4MB on x64
+#else
+	static unicode buf[65536]; // 128KB on i386
+#endif
 	for( ulong i=0; tf->state(); )
 	{
 		if( size_t L = tf->ReadLine( buf, countof(buf) ) )


### PR DESCRIPTION
1) Improves performances a lot when you have long lines in a file.
Without that a couple MB is the maximum length of a single line that can be loaded in human times.
Performances are not much improved for lines length smaller than the buffer size.
2) Minimize memory allocation in ip_doc.h. It does not seems to decrease much performances, and it helps loading larger files without running out of memory. There is not much reason to round up memory allocation because it is rarely enough anyway until the end of the line. Plus memmove() dominate computation time, not new/delete.