### PR TITLE
Fix KB Input on Win9x and Copy/Paste handling

### DIFF
--- a/editwing/ip_cursor.cpp
+++ b/editwing/ip_cursor.cpp
@@ -311,7 +311,7 @@ void CurEvHandler::on_key( Cursor& cur, int vk, bool sft, bool ctl )
 void Cursor::on_char( TCHAR ch )
 {
 	if( !bRO_ && ch!=0x7f
-	 && ((unsigned)ch>=0x20 || ch==TEXT('\r') || ch==TEXT('\t')) )
+	&& ((unsigned)ch>=0x20 || ch==TEXT('\r') || ch==TEXT('\t')) )
 	{
 		if( UNICODEBOOL && app().isNT() )
 		{ // In unicode mode we have Wide Chars ON NT
@@ -320,6 +320,18 @@ void Cursor::on_char( TCHAR ch )
 		else
 		{
 			unicode wc = ch;
+//			if (IsDBCSLeadByte(ch))
+//			{ // store and block DBCSLeadByte
+//				prevchar_ = ch;
+//				return;
+//			}
+//			else if (IsDBCSLeadByte(prevchar_))
+//			{
+//				unsigned x = (prevchar_) | (ch<<8);
+//				prevchar_ = 0;
+//				::MultiByteToWideChar( CP_ACP, MB_COMPOSITE, (char*)&x, 2, &wc, 1 );
+//			}
+//			else
 			if( ch & 0x80 ) // 非ASCII文字にはトリビアルでない変換が必要
 			{
 				// Non-ASCII characters require non-trivial conversion.

--- a/editwing/ip_cursor.cpp
+++ b/editwing/ip_cursor.cpp
@@ -347,8 +347,8 @@ void Cursor::on_ime_composition( LPARAM lp )
 	view_.ScrollTo( cur_ );
 	if( !bRO_ && (lp&GCS_RESULTSTR) )
 	{
-		unicode* str;
-		ulong    len;
+		unicode* str=NULL;
+		ulong    len=0;
 		ime().GetString( caret_->hwnd(), &str, &len );
 		if( str )
 		{
@@ -542,7 +542,7 @@ void Cursor::Tabulation(bool shi)
 {
 	if (cur_.tl == sel_.tl)
 	{
-		Input("\t", 1);
+		Input(TEXT("\t"), 1);
 		return;	 // DONE
 	}
 	QuoteSelectionW(L"\t", shi); // Quote with a tab!

--- a/kilib/stdafx.h
+++ b/kilib/stdafx.h
@@ -21,11 +21,14 @@
 #include <imm.h>
 // dimm.hが無くてエラーになる場合、プロジェクトの設定でUSEGLOBALIMEの定義を
 // 削除するか、最新の Platform SDK を導入すればビルドが通るようになります。
-#if defined(USEGLOBALIME) && defined(TARGET_VER) && TARGET_VER<=300
-#undef USEGLOBALIME
-#endif
 #ifdef USEGLOBALIME
 #include <dimm.h>
+#endif
+
+#ifdef _UNICODE
+  #define UNICODEBOOL true
+#else 
+  #define UNICODEBOOL false
 #endif
 
 #ifndef NO_MLANG

--- a/kilib/window.cpp
+++ b/kilib/window.cpp
@@ -311,9 +311,6 @@ void IMEManager::SetPos( HWND wnd, int x, int y )
 
 void IMEManager::GetString( HWND wnd, unicode** str, ulong* len )
 {
-	*str = NULL;
-	len=0;
-
 #ifndef NO_IME
 	HIMC ime;
 	#ifdef USEGLOBALIME
@@ -355,7 +352,7 @@ void IMEManager::GetString( HWND wnd, unicode** str, ulong* len )
 			}
 
 		::ImmReleaseContext( wnd, ime );
-	} // endif (hasIMM32_)
+	} // end if (hasIMM32_)
 #endif //NO_IME
 }
 

--- a/kilib/winutil.cpp
+++ b/kilib/winutil.cpp
@@ -28,9 +28,10 @@ Clipboard::~Clipboard()
 
 Clipboard::Text Clipboard::GetUnicodeText() const
 {
-	if( app().isNT() )
+	if( UNICODEBOOL || app().isNT() )
 	{
 		// NTÇ»ÇÁíºê⁄UnicodeÇ≈Ç∆ÇÍÇÈ
+		// Also on Win9x we can use CF_UNICODETEXT with UNICOWS
 		HANDLE h = GetData( CF_UNICODETEXT );
 		if( h != NULL )
 		{
@@ -38,32 +39,14 @@ Clipboard::Text Clipboard::GetUnicodeText() const
 			return Text( ustr, Text::GALLOC );
 		}
 	}
-	else
+
+	#ifndef _UNICODE
 	{
+		// Fallback to ANSI clipboard data.
 		// 9xÇ»ÇÁïœä∑Ç™ïKóv
 		HANDLE h = GetData( CF_TEXT );
 		if( h != NULL )
 		{
-//			// Seems useless on Win9x where no per-thread local are possible
-//			// Try to get local id info from Clipboard
-//			LCID *lcidpt = (LCID*)GetData( CF_LOCALE );
-//			LCID lcid=0;
-//			if (lcidpt) {
-//				lcid = *(LCID*)::GlobalLock( lcidpt ) ;;
-//				::GlobalUnlock( lcidpt );
-//			}
-//			UINT clipCP = CP_ACP; // default ACP
-//			TCHAR cpstr[32];
-//			if(::IsValidLocale(lcid, LCID_INSTALLED)
-//			&& ::GetLocaleInfo(lcid, LOCALE_IDEFAULTANSICODEPAGE, cpstr, countof(cpstr)))
-//			{	// This should be the codepage of the local associated with
-//				// the clipboard content, might be different than the default CP_ACP
-//				// Or can it?
-//				UINT tcp = String::GetInt(cpstr);
-//				if (tcp) clipCP = tcp;
-//				// MessageBox(NULL, cpstr, NULL, 0);
-//			}
-
 			char* cstr = static_cast<char*>( ::GlobalLock( h ) );
 			int Lu = my_lstrlenA( cstr ) * 3;
 			unicode* ustr = new unicode[Lu];
@@ -72,45 +55,49 @@ Clipboard::Text Clipboard::GetUnicodeText() const
 			return Text( ustr, Text::NEW );
 		}
 	}
-	// No "normal" text in the clipboard...
-	// Maybe paste a list of files?
-	HDROP h = (HDROP)GetData( CF_HDROP );
-	if( h != NULL )
+	#endif
+
 	{
-	    h = (HDROP)::GlobalLock( h );
-		UINT nf = DragQueryFile(h, 0xFFFFFFFF, NULL, 0);
-		size_t totstrlen=0;
-		UINT *lenmap = new UINT[nf];
-		for (uint i=0; i < nf; i++)
-		{	// On Windows NT3.1 DragQueryFile() does not return
-			// The required buffer length hence the Min()...
-			lenmap[i] = Min((UINT)MAX_PATH, DragQueryFile(h, i, NULL, 0));
-			totstrlen += lenmap[i];
-		}
-		unicode* ustr = new unicode[totstrlen+2*nf+1];
-		unicode* ptr=ustr; *ptr = L'\0';
-		for (UINT i=0; i < nf; i++)
+		// No "normal" text in the clipboard...
+		// Maybe paste a list of files?
+		HDROP h = (HDROP)GetData( CF_HDROP );
+		if( h != NULL )
 		{
-			// Return the length without NULL and requires length with NULL
-			#if UNICODE
-			ptr += DragQueryFileW(h, i, ptr, Min(lenmap[i]+1, (UINT)MAX_PATH));
-			#else
-			{
-				char buf[MAX_PATH]; // MAX_PATH is the maximum in ANSI mode
-				UINT len = DragQueryFileA(h, i, buf, MAX_PATH);
-				::MultiByteToWideChar( CP_ACP, 0, buf, len, ptr, len );
-				ptr+=len;
+			h = (HDROP)::GlobalLock( h );
+			UINT nf = DragQueryFile(h, 0xFFFFFFFF, NULL, 0);
+			size_t totstrlen=0;
+			UINT *lenmap = new UINT[nf];
+			for (uint i=0; i < nf; i++)
+			{	// On Windows NT3.1 DragQueryFile() does not return
+				// The required buffer length hence the Min()...
+				lenmap[i] = Min((UINT)MAX_PATH, DragQueryFile(h, i, NULL, 0));
+				totstrlen += lenmap[i];
 			}
-			#endif
+			unicode* ustr = new unicode[totstrlen+2*nf+1];
+			unicode* ptr=ustr; *ptr = L'\0';
+			for (UINT i=0; i < nf; i++)
+			{
+				// Return the length without NULL and requires length with NULL
+				#if UNICODE
+				ptr += DragQueryFileW(h, i, ptr, Min(lenmap[i]+1, (UINT)MAX_PATH));
+				#else
+				{
+					char buf[MAX_PATH]; // MAX_PATH is the maximum in ANSI mode
+					UINT len = DragQueryFileA(h, i, buf, MAX_PATH);
+					::MultiByteToWideChar( CP_ACP, 0, buf, len, ptr, len );
+					ptr+=len;
+				}
+				#endif
 
-			*ptr++ = L'\r';
-			*ptr++ = L'\n';
+				*ptr++ = L'\r';
+				*ptr++ = L'\n';
+			}
+			*ptr++ = L'\0';
+			GlobalUnlock( h );
+			delete [] lenmap;
+
+			return Text( ustr, Text::NEW );
 		}
-		*ptr++ = L'\0';
-		GlobalUnlock( h );
-		delete [] lenmap;
-
-		return Text( ustr, Text::NEW );
 	}
 
 	return Text( NULL, Text::NEW );

--- a/kilib/winutil.cpp
+++ b/kilib/winutil.cpp
@@ -28,7 +28,8 @@ Clipboard::~Clipboard()
 
 Clipboard::Text Clipboard::GetUnicodeText() const
 {
-	if( UNICODEBOOL || app().isNT() )
+	// Always try to get the best available clipboard data.
+	if( IsClipboardFormatAvailable(CF_UNICODETEXT) )
 	{
 		// NTÇ»ÇÁíºê⁄UnicodeÇ≈Ç∆ÇÍÇÈ
 		// Also on Win9x we can use CF_UNICODETEXT with UNICOWS
@@ -41,6 +42,8 @@ Clipboard::Text Clipboard::GetUnicodeText() const
 	}
 
 	#ifndef _UNICODE
+	// ANSI text, not needed in Unicode/Unicows builds
+	else if( IsClipboardFormatAvailable(CF_TEXT) )
 	{
 		// Fallback to ANSI clipboard data.
 		// 9xÇ»ÇÁïœä∑Ç™ïKóv
@@ -57,6 +60,7 @@ Clipboard::Text Clipboard::GetUnicodeText() const
 	}
 	#endif
 
+	else if( IsClipboardFormatAvailable(CF_HDROP) )
 	{
 		// No "normal" text in the clipboard...
 		// Maybe paste a list of files?
@@ -99,6 +103,5 @@ Clipboard::Text Clipboard::GetUnicodeText() const
 			return Text( ustr, Text::NEW );
 		}
 	}
-
 	return Text( NULL, Text::NEW );
 }


### PR DESCRIPTION
1) Even with UNICOWS the WM_CHAR just sends ANSI characters.
This is not correct as you may use alternate keyboard (Greek for example). 
In this case I convert manually to Unicode using the input keyboard lcid from which I retrieve the input code page.
This can be improved by creating a simple `LCIDtoCP()` function (could be a big switch) also the input_cp should be cached but it aint slow anyway...

2) In UNICOWS mode on windows 9x you can use the CF_UNICODETEXT format. You have to set manually also the CF_TEXT for unicode aware applications. This seems crazy but it seems to work, and I know have full unicode Copy/Paste on Windows 9x