### PR TITLE
Take SPI_GETWHEELSCROLLLINES parameter in account

### DIFF
--- a/editwing/ip_scroll.cpp
+++ b/editwing/ip_scroll.cpp
@@ -543,10 +543,25 @@ void ViewImpl::on_vscroll( int code, int pos )
 	UpDown( dy, code==SB_THUMBTRACK );
 }
 
+int ViewImpl::getNumScrollLines( void )
+{
+	uint scrolllines = 3; // Number of lines to scroll (default 3).
+	if( App::getOSVer() >= 400 )
+	{   // Read the system value for the wheel scroll lines.
+		UINT numlines;
+		if( ::SystemParametersInfo( SPI_GETWHEELSCROLLLINES, 0, &numlines, 0 ) )
+			scrolllines = numlines; // Sucess!
+	}
+	// If the number of lines is larger than a single page then we only scroll a page.
+	// This automatically takes into account the page scroll mode where
+	// SPI_GETWHEELSCROLLLINES value if 0xFFFFFFFF.
+	return (int)Min( scrolllines, (uint)cy() / (uint)NZero(cvs_.getPainter().H()) );
+}
+
 void ViewImpl::on_wheel( short delta )
 {
 	// ÉXÉNÉçÅ[Éã
-	UpDown( -delta / WHEEL_DELTA * 3, false );
+	UpDown( (-(int)delta * getNumScrollLines()) / WHEEL_DELTA, false );
 }
 
 void ViewImpl::UpDown( int dy, bool thumb )

--- a/editwing/ip_view.h
+++ b/editwing/ip_view.h
@@ -357,6 +357,7 @@ public:
 	void ConvDPosToVPos( DPos dp, VPos* vp, const VPos* base=NULL ) const;
 	void ScrollTo( const VPos& vp );
 	int  GetLastWidth( ulong tl ) const;
+	int  getNumScrollLines( void );
 
 public:
 


### PR DESCRIPTION
This is a bug fix:
GreenPad now takes the number of lines for a scroll event into account. Also the patch avoids scrolling more than a single page when scroll step is larger than the current view's height (even Microsoft recommends that).

Also the multiplication by number of lines must be done before the division by WHEEL_DELTA(=120), otherwise when delta is smaller that 120 it does not scroll at all! Some mouses with fine wheel can do that.

I know the NZero() is completely overkill but I am always paranoid about divisions by zero (just me).

@roytam1 you might be interested by this patch.