### PR TITLE
Font unicode range

### DIFF
--- a/kilib/ktlgap.h
+++ b/kilib/ktlgap.h
@@ -44,8 +44,8 @@ public:
 	//		最初に確保する"メモリの"サイズ。
 	//		"配列の"サイズではないことに注意。
 	//@}
-	explicit gapbuf( ulong alloc_size=40 )
-		: alen_( Max(alloc_size, (ulong)10) )
+	explicit gapbuf( ulong alloc_size=32 )
+		: alen_( Max(alloc_size, (ulong)16) )
 		, gs_  ( 0 )
 		, ge_  ( alen_ )
 		, buf_ ( new T[alen_] )
@@ -208,7 +208,7 @@ class gapbufobj : public gapbuf<T*>
 {
 public:
 
-	explicit gapbufobj( ulong alloc_size=40 )
+	explicit gapbufobj( ulong alloc_size=32 )
 		: gapbuf<T*>( alloc_size )
 		{ }
 

--- a/kilib/textfile.h
+++ b/kilib/textfile.h
@@ -30,6 +30,7 @@ enum charset {
 
 	WesternDOS = 850,  // ‰¢•Ä      (CP850 != ISO-8859-1)
 	Western    = 1252, // ‰¢•Ä      (Windows1252 >> ISO-8859-1)
+//	WesternOS2 = 1004  // CP1004 OS/2 encoding ~ Windows1252
 	WesternMAC = 10000,// ‰¢•Ä      (x-mac-roman != ISO-8859-1)
 	WesternISO = 28605,// ‰¢•Ä      (ISO-8859-15)
 	TurkishDOS = 857,  // ƒgƒ‹ƒRŒê   (CP857 != ISO-8859-9)

--- a/kilib/types.h
+++ b/kilib/types.h
@@ -28,12 +28,26 @@ template<typename T> inline T NZero(T x)   { return (x==0? 1 : x); }
 
 // 古いC++処理系でも、forで使う変数のスコープを強制的に制限
 #if defined(_MSC_VER) || defined(__DMC__)
-#define for if(0);else for 
+#define for if(0);else for
 #endif
 
 // コピー禁止オブジェクト
 #define NOCOPY(T) T( const T& ); T& operator=( const T& )
 
+#ifndef GS_8BIT_INDICES
+#define GS_8BIT_INDICES 0x00000001
+typedef struct tagWCRANGE {
+  WCHAR wcLow;
+  USHORT cGlyphs;
+} WCRANGE,*PWCRANGE,*LPWCRANGE;
 
+typedef struct tagGLYPHSET {
+  DWORD   cbThis;
+  DWORD   flAccel;
+  DWORD   cGlyphsSupported;
+  DWORD   cRanges;
+  WCRANGE ranges[1];
+} GLYPHSET, *PGLYPHSET, *LPGLYPHSET;
+#endif
 
 #endif // _KILIB_TYPES_H_


### PR DESCRIPTION
Under newer windows there is a fallback font that is used when the selected font does not contain the character Because of this the GetCharWidthW() function gives the default char width (without error) and we end-up with a wrong width. To minimize the problem we can use GetTextExtentPointW() when the character is not in the font's Unicode ranges.