### PR TITLE
Make the Mutex class actually wait for ownership

### DIFF
--- a/kilib/winutil.h
+++ b/kilib/winutil.h
@@ -52,7 +52,7 @@ public:
 			: str_(t.str_), mem_(t.mem_) { t.str_=NULL; }
 		~Text()
 			{
-				if( str_ != NULL ) 
+				if( str_ != NULL )
 				{
 					if( mem_==NEW ) delete [] str_;
 					else      GlobalUnlock( str_ );
@@ -134,10 +134,11 @@ private:
 //-------------------------------------------------------------------------
 
 inline Mutex::Mutex( const TCHAR* name )
-	: mtx_( ::CreateMutex( NULL, TRUE, name ) ) 
+	: mtx_( ::CreateMutex( NULL, TRUE, name ) )
 	{
-//		if (mtx_ && ::GetLastError() == ERROR_ALREADY_EXISTS)
-//			::WaitForSingleObject(mtx_, 1000);
+		// Wait for Mutex ownership, in case it was already created.
+		if( mtx_ && ::GetLastError() == ERROR_ALREADY_EXISTS )
+			::WaitForSingleObject(mtx_, 10000); // 10 sec max.
 	}
 
 inline Mutex::~Mutex()

--- a/kilib/winutil.h
+++ b/kilib/winutil.h
@@ -121,9 +121,11 @@ class Mutex : public Object
 public:
 	Mutex( const TCHAR* name );
 	~Mutex();
+	bool isLocked() const;
 
 private:
 	const HANDLE mtx_;
+	bool locked_;
 
 private:
 	NOCOPY(Mutex);
@@ -135,14 +137,30 @@ private:
 
 inline Mutex::Mutex( const TCHAR* name )
 	: mtx_( ::CreateMutex( NULL, TRUE, name ) )
+	, locked_ (false)
 	{
-		// Wait for Mutex ownership, in case it was already created.
-		if( mtx_ && ::GetLastError() == ERROR_ALREADY_EXISTS )
-			::WaitForSingleObject(mtx_, 10000); // 10 sec max.
+		if( mtx_ )
+		{
+			// Wait for Mutex ownership, in case it was already created.
+			if( ::GetLastError() == ERROR_ALREADY_EXISTS )
+				// Wait 10 second for ownership of fail.
+				locked_ = WAIT_OBJECT_0 == ::WaitForSingleObject(mtx_, 1000);
+			else
+				locked_ = true; // The mutex is ours.
+		}	
 	}
 
+inline bool Mutex::isLocked() const
+	{ return locked_; }
+
 inline Mutex::~Mutex()
-	{ if( mtx_ != NULL ) ::ReleaseMutex( mtx_ ), ::CloseHandle( mtx_ ); }
+	{
+		if( mtx_ != NULL )
+		{
+			if( locked_ ) ::ReleaseMutex( mtx_ );
+			::CloseHandle( mtx_ );
+		}
+	}
 
 
 


### PR DESCRIPTION
I do not see point in creating Mutexes and ignoring them.
I already thought about this but it was commented-out.

One a CreateMutex() is called the thread should wait to own the mutex before going on with the business, then at the end the Mutex must be released and handle closed for each call to CreateMutex()

Mutex is only used for MRU stuff (file reading and writing) so that two processes cannot read/write the ini file at the same time.

@roytam1 maybe you would have more insights about this.