### PR TITLE
Improve OSVersion checking

### DIFF
--- a/GpMain.cpp
+++ b/GpMain.cpp
@@ -15,7 +15,7 @@ void BootNewProcess( const TCHAR* cmd = TEXT("") )
 	// On NT5 it seems ok to use "exe name.exe" "file name"
 	// Otherwise we try SHORT/NAME.EXE "file name"
 	// I do not know why the heck it is like this.
-	bool quotedexe = app().getOSVer() >= 500 && app().isNT();
+	bool quotedexe = app().getOOSVer() >= 0x05000000 && app().isNT();
 	String fcmd;
 	if( quotedexe ) fcmd = TEXT("\"");
 	fcmd += quotedexe? Path(Path::ExeName): Path(Path::ExeName).BeShortStyle();
@@ -394,7 +394,7 @@ int GreenPadWnd::resolvedCSI()
 void GreenPadWnd::on_openelevated(const ki::Path& fn)
 {
 	// Only supported since Windows 2000
-	if( app().getOSVer() < 500 )
+	if( app().getOOSVer() < 0x05000000 )
 		return;
 
 	const view::VPos *cur, *sel;
@@ -449,8 +449,8 @@ BOOL GreenPadWnd::myPageSetupDlg(LPPAGESETUPDLG lppsd)
 #elif defined(UNICOWS)
 	// In unicows mode the PageSetupDlg is already
 	// dynamically loaded, so we just check for OSVer.
-	if( App::isNTOSVerLarger( 351, 1057 )
-	||  App::is9xOSVerLarger( 400, 950 ) )
+	if( app().isNTOSVerLarger(MKVER(3,51,1057))
+	||  app().is9xOSVerLarger(MKVER(4,00,950)) )
 	{
 		return PageSetupDlg(lppsd); // NT3.51/95+
 	}
@@ -706,7 +706,7 @@ void GreenPadWnd::on_initmenu( HMENU menu, bool editmenu_only )
 
 	::EnableMenuItem( menu, ID_CMD_SAVEFILE, MF_BYCOMMAND|(isUntitled() || edit_.getDoc().isModified() ? MF_ENABLED : MF_GRAYED) );
 	::EnableMenuItem( menu, ID_CMD_REOPENFILE, MF_BYCOMMAND|(!isUntitled() ? MF_ENABLED : MF_GRAYED) );
-	::EnableMenuItem( menu, ID_CMD_OPENELEVATED, MF_BYCOMMAND|( app().getOSVer() >= 500 ? MF_ENABLED : MF_GRAYED) );
+	::EnableMenuItem( menu, ID_CMD_OPENELEVATED, MF_BYCOMMAND|( app().getOOSVer() >= 0x05000000 ? MF_ENABLED : MF_GRAYED) );
 	::EnableMenuItem( menu, ID_CMD_GREP, MF_BYCOMMAND|(cfg_.grepExe().len()>0 ? MF_ENABLED : MF_GRAYED) );
 
 	::CheckMenuItem( menu, ID_CMD_NOWRAP, MF_BYCOMMAND|(wrap_==-1?MF_CHECKED:MF_UNCHECKED));
@@ -911,7 +911,8 @@ static BOOL CALLBACK MyFindWindowExProc(HWND hwnd, LPARAM lParam)
 static HWND MyFindWindowEx(HWND parent, HWND after, LPCTSTR lpszClass, LPCTSTR lpszWindow)
 {
   # if !defined (TARGET_VER) || defined(UNICODE) && defined(UNICOWS)
-	if (app().isNewShell()) {
+	if( app().isNewShell() )
+	{
 		// In UNICOWS mode FindWindowEx is dynamically
 		// imported and is implemented for 95/NT4+
 		return FindWindowEx(parent, after, lpszClass, lpszWindow);
@@ -1230,7 +1231,7 @@ bool GreenPadWnd::OpenByMyself( const ki::Path& fn, int cs, bool needReConf, boo
 		MsgBox( fnerror.c_str(), String(IDS_OPENERROR).c_str() );
 		return false; // Failed to open.
 	}
-	else if ( app().getOSVer() >= 500 )
+	else if ( app().getOOSVer() >= 0x05000000 )
 	{
 		// Check for Write access and Prompt the user
 		// if he would like to elevate so the file can be written.

--- a/OpenSaveDlg.cpp
+++ b/OpenSaveDlg.cpp
@@ -162,11 +162,13 @@ CharSetList::CharSetList()
 
 void CharSetList::EnrollCs(int _id, ushort nmtype)
 {
+	#if !defined(TARGET_VER) || TARGET_VER >= 350
 	static const TCHAR* const lnmJp[] = {
 		#define CHARSET_VALUE(a,b,c) TEXT(a),
 		CHARSETS_LIST
 		#undef CHARSET_VALUE
 	};
+	#endif
 
 	static const TCHAR* const lnmEn[] = {
 		#define CHARSET_VALUE(a,b,c) TEXT(b),
@@ -358,7 +360,7 @@ bool OpenFileDlg::DoModal( HWND wnd, const TCHAR* fltr, const TCHAR* fnm )
 				OFN_LONGNAMES     |
 				OFN_CREATEPROMPT;
 
-	if (app().isNewShell())
+	if( app().isNewShell() )
 	{
 		// Include the OFN_EXPLORER flag to get the new look.
 		ofn.Flags |= OFN_EXPLORER;
@@ -489,7 +491,7 @@ bool SaveFileDlg::DoModal( HWND wnd, const TCHAR* fltr, const TCHAR* fnm )
 				OFN_OVERWRITEPROMPT |
 				OFN_LONGNAMES;
 
-	if (app().isNewShell())
+	if( app().isNewShell() )
 	{
 		// Include the OFN_EXPLORER flag to get the new look.
 		ofn.Flags |= OFN_EXPLORER;

--- a/editwing/ip_cursor.cpp
+++ b/editwing/ip_cursor.cpp
@@ -15,7 +15,7 @@ static BOOL WINAPI myIsDBCSLeadByteEx_1st(UINT cp, BYTE ch)
 {
 	myIsDBCSLeadByteEx = myIsDBCSLeadByteEx_fb;
 
-	if( App::isNT() || App::is9xOSVerLarger(400, 950) )
+	if( app().isNT() || app().is9xOSVerLarger( MKVER(4,00,950)) )
 	{
 		// On Chicago build 116 We get a crash when using IsDBCSLeadByteEx
 		// TODO: find exactly which build is required...
@@ -381,7 +381,7 @@ void Cursor::on_char( TCHAR ch )
 	if( !bRO_ && ch!=0x7f
 	&& ((unsigned)ch>=0x20 || ch==TEXT('\r') || ch==TEXT('\t')) )
 	{
-		if( UNICODEBOOL && App::isNT() )
+		if( UNICODEBOOL && app().isNT() )
 		{ // In unicode mode we have Wide Chars ON NT
 			pEvHan_->on_char( *this, ch );
 		}
@@ -693,7 +693,7 @@ void Cursor::Copy()
 	HGLOBAL  h;
 	ulong len = doc_.getRangeLength( dm, dM );
 
-	if( UNICODEBOOL || App::isNT() )
+	if( UNICODEBOOL || app().isNT() )
 	{
 		// NT系ならそのままダイレクトに, Direct copy
 		// Also on Win9x we can use CF_UNICODETEXT with UNICOWS
@@ -717,7 +717,7 @@ void Cursor::Copy()
 	}
 
 #if !defined(_UNICODE) || defined(UNICOWS)
-	if( !App::isNT() )
+	if( !app().isNT() )
 	{
 		// On 9x With UNICOWS We need to also write to the clipboard in ANSI
 		// So that other programs can access the clipboard.
@@ -858,7 +858,7 @@ void Cursor::ModSelection(ModProc mfunk)
 void Cursor::UpperCaseSel()
 {
 #if defined(UNICOWS) || !defined(_UNICODE)
-	ModSelection(App::isNT()? CharUpperW: my_CharUpperW);
+	ModSelection(app().isNT()? CharUpperW: my_CharUpperW);
 #else
 	ModSelection(CharUpperW);
 #endif
@@ -866,7 +866,7 @@ void Cursor::UpperCaseSel()
 void Cursor::LowerCaseSel()
 {
 #if defined(UNICOWS) || !defined(_UNICODE)
-	ModSelection(App::isNT()? CharLowerW: my_CharLowerW);
+	ModSelection(app().isNT()? CharLowerW: my_CharLowerW);
 #else
 	ModSelection(CharLowerW);
 #endif

--- a/editwing/ip_draw.cpp
+++ b/editwing/ip_draw.cpp
@@ -258,7 +258,7 @@ Painter::Painter( HDC hdc, const VConfig& vc )
 	// 文字幅テーブル初期化（ASCII範囲の文字以外は遅延処理）
 	memFF( widthTable_, 65536*sizeof(*widthTable_) );
 #ifdef WIN32S
-	if (App::isWin32s() )
+	if ( app().isWin32s() )
 	{
 		#ifndef SHORT_TABLEWIDTH
 		::GetCharWidthA( dc_, ' ', '~', widthTable_+' ' );
@@ -354,29 +354,19 @@ Painter::~Painter()
 inline void Painter::CharOut( unicode ch, int x, int y )
 {
 #ifdef WIN32S
-	// Actually for now we only use CharOut for ASCII characters that
-	if( App::isWin32s() )
-	{
-//		char psText[8]; // Buffer for a SINGLE multibyte character
-//		DWORD dwNum = 1;
-//		psText[0] = (char)ch;
-//		if( ch > 127 ) // Complex converion.
-//			dwNum = ::WideCharToMultiByte( CP_ACP,0, &ch,1, psText,countof(psText), NULL,NULL );
-//		::TextOutA( dc_, x, y, psText, dwNum );
-		::TextOutA( dc_, x, y, (char*)&ch, 1 ); // Only ASCII!!!
-	}
-	else
+	// Actually for now we only use CharOut for ASCII characters
+	::TextOutA( dc_, x, y, (char*)&ch, 1 ); // Only ASCII!!!
+#else
+	// Windows 9x/NT
+	::TextOutW( dc_, x, y, &ch, 1 );
 #endif
-	{ // Windows 9x/NT
-		::TextOutW( dc_, x, y, &ch, 1 );
-	}
 }
 
 inline void Painter::StringOut
 	( const unicode* str, int len, int x, int y )
 {
 #ifdef WIN32S
-	if( App::isWin32s() )
+	if( app().isWin32s() )
 	{
 		DWORD dwNum;
 		char psTXT1K[1024];
@@ -722,13 +712,6 @@ void ViewImpl::DrawTXT( const VDrawInfo v, Painter& p )
 					if( p.sc(scHSP) )
 						p.DrawHSP( x+v.XBASE, a.top, i2-i );
 					break;
-//				case 0x00a0: // NBSP No-Break Space
-//					if( p.sc(scZSP) )
-//					{
-//						p.SetColor( clr=CTL );
-//						p.CharOut( L'^', x+v.XBASE, a.top );
-//					}
-//					break;
 				case 0x3000://L'　':
 					if( p.sc(scZSP) )
 						p.DrawZSP( x+v.XBASE, a.top, i2-i );

--- a/editwing/ip_scroll.cpp
+++ b/editwing/ip_scroll.cpp
@@ -60,8 +60,8 @@ static int WINAPI MySetScrollInfo_1st(HWND hwnd, int fnBar, LPSCROLLINFO lpsi, B
 	// Should be supported since Windows NT 3.51.944
 	ssnfo_funk dyn_SetScrollInfo = (ssnfo_funk)GetProcAddress(GetModuleHandleA("USER32.DLL"), "SetScrollInfo");
 	if( dyn_SetScrollInfo
-	&& !(  App::is9xOSVerLarger(400, 275) // Win95 4.00.275
-		|| App::isNTOSVerLarger(351, 944) // WinNT 3.51.944
+	&& !(  app().is9xOSVerLarger( MKVER(4,00,275) ) // Win95 4.00.275
+		|| app().isNTOSVerLarger( MKVER(3,51,944) ) // WinNT 3.51.944
 	    ) )
 	{   // Not supported before 95 build 275
 		// Nor NT3.51 before build 944
@@ -105,8 +105,8 @@ static int WINAPI MyGetScrollInfo_1st(HWND hwnd, int fnBar, LPSCROLLINFO lpsi)
 	// Should be supported since Windows NT 3.51...
 	gsnfo_funk dyn_GetScrollInfo = (gsnfo_funk)GetProcAddress(GetModuleHandleA("USER32.DLL"), "GetScrollInfo");
 	if( dyn_GetScrollInfo
-	&& !(  App::is9xOSVerLarger(400, 275) // Win95 4.00.275
-		|| App::isNTOSVerLarger(351, 944) // WinNT 3.51.944
+	&& !(  app().is9xOSVerLarger(MKVER(4,00,275)) // Win95 4.00.275
+		|| app().isNTOSVerLarger(MKVER(3,51,944)) // WinNT 3.51.944
 	    ) )
 	{
 		dyn_GetScrollInfo = NULL;
@@ -603,7 +603,7 @@ void ViewImpl::on_vscroll( int code, int pos )
 int ViewImpl::getNumScrollLines( void )
 {
 	uint scrolllines = 3; // Number of lines to scroll (default 3).
-	if( App::getOSVer() >= 400 )
+	if( app().getOOSVer() >= 0x04000000 )
 	{   // Read the system value for the wheel scroll lines.
 		UINT numlines;
 		if( ::SystemParametersInfo( SPI_GETWHEELSCROLLLINES, 0, &numlines, 0 ) )
@@ -645,13 +645,13 @@ int ViewImpl::getNumScrollRaws( void )
 {
 	uint scrollnum = 3; // Number of lines to scroll (default 3).
 	// TODO: Get more accurate version numbers for scroll wheel support?
-	if ( App::getOSVer() >= 600 )
+	if ( app().getOOSVer() >= 0x06000000 )
 	{ // Introduced in window Vista
 		UINT num;
 		if( ::SystemParametersInfo( SPI_GETWHEELSCROLLCHARS, 0, &num, 0 ) )
 			scrollnum = num; // Sucess!
 	}
-	else if( App::getOSVer() >= 400 )
+	else if( app().getOOSVer() >= 0x04000000 )
 	{   // Read the system value for the wheel scroll lines.
 		UINT num;
 		if( ::SystemParametersInfo( SPI_GETWHEELSCROLLLINES, 0, &num, 0 ) )

--- a/editwing/ip_view.h
+++ b/editwing/ip_view.h
@@ -100,7 +100,7 @@ public:
 				return 2 * widthTable_[ L'x' ];
 			}
 #ifdef WIN32S
-			if( App::isWin32s() )
+			if( app().isWin32s() )
 			{
 				if( ch > 0x100 )
 				{
@@ -187,7 +187,7 @@ private:
 	const HPEN   pen_;
 	const HBRUSH brush_;
 	CW_INTTYPE   height_;
-	CW_INTTYPE*  widthTable_; // int or char [65535] values
+	CW_INTTYPE*  widthTable_; // int or short [65535] values
 	CW_INTTYPE   figWidth_;
 	LOGFONT      logfont_;
 	GLYPHSET     *fontranges_;

--- a/kilib/app.h
+++ b/kilib/app.h
@@ -5,6 +5,9 @@
 
 HRESULT MyCoCreateInstance(REFCLSID rclsid, LPUNKNOWN pUnkOuter, DWORD dwClsContext, REFIID riid, LPVOID *ppv);
 
+// Use to make a ordered window version ie: MKVER(3,10,511) = 0x030A01FF
+#define MKVER(M, m, b) ( (DWORD)( (BYTE)(M)<<24 | (BYTE)(m)<<16 | (WORD)(b) ) )
+
 #ifndef __ccdoc__
 namespace ki {
 #endif
@@ -91,22 +94,21 @@ public:
 	HINSTANCE       hOle32_;
 
 	//@{ Windows‚Ìƒo[ƒWƒ‡ƒ“ //@}
-	static const OSVERSIONINFOA& osver();
-	static DWORD getOSVer();
-	static DWORD getOSBuild();
-	static bool isOSVerLarger(DWORD ver, DWORD build);
-	static bool is9xOSVerLarger(DWORD ver, DWORD build);
-	static bool isNTOSVerLarger(DWORD ver, DWORD build);
-	static bool isOSVerEqual(DWORD ver, DWORD build);
-	static bool is9xOSVerEqual(DWORD ver, DWORD build);
-	static bool isNTOSVerEqual(DWORD ver, DWORD build);
-	static bool isWin95();
-	static bool isNT();
-	static bool isWin32s();
-	static bool is351p();
-	static bool isNT31();
-	static bool isNewShell();
-	static bool isNewTypeWindows();
+	void init_osver();
+	DWORD getOSVer() const;
+	DWORD getOSBuild() const;
+	DWORD getOOSVer() const;
+	bool isOSVerLarger(DWORD ver) const;
+	bool is9xOSVerLarger(DWORD ver) const;
+	bool isNTOSVerLarger(DWORD ver) const;
+	bool isOSVerEqual(DWORD ver) const;
+	bool is9xOSVerEqual(DWORD ver) const;
+	bool isNTOSVerEqual(DWORD ver) const;
+	bool isWin95() const;
+	bool isNT() const;
+	bool isWin32s() const;
+	bool isNewShell() const;
+	bool isNewTypeWindows() const;
 
 private:
 
@@ -115,7 +117,8 @@ private:
 	void SetExitCode( int code );
 
 private:
-
+	OSVERSIONINFOA  osver_;
+	DWORD           oosver_;
 	int             exitcode_;
 	ulong           loadedModule_;
 	const HINSTANCE hInst_;

--- a/kilib/app.h
+++ b/kilib/app.h
@@ -94,7 +94,6 @@ public:
 	HINSTANCE       hOle32_;
 
 	//@{ WindowsÇÃÉoÅ[ÉWÉáÉì //@}
-	void init_osver();
 	DWORD getOSVer() const;
 	DWORD getOSBuild() const;
 	DWORD getOOSVer() const;
@@ -115,10 +114,11 @@ private:
 	App();
 	~App();
 	void SetExitCode( int code );
+	OSVERSIONINFOA init_osver();
 
 private:
-	OSVERSIONINFOA  osver_;
-	DWORD           oosver_;
+	const OSVERSIONINFOA  osver_;
+	const DWORD     oosver_;
 	int             exitcode_;
 	ulong           loadedModule_;
 	const HINSTANCE hInst_;

--- a/kilib/ctrl.cpp
+++ b/kilib/ctrl.cpp
@@ -65,7 +65,7 @@ bool StatusBar::PreTranslateMessage( MSG* )
 void StatusBar::SetText( const TCHAR* str, int part )
 {
 #if defined(UNICOWS) && defined(UNICODE)
-	if ( app().isNTOSVerLarger(350, 711) )
+	if ( app().isNTOSVerLarger(MKVER(3,50,711)) )
 	{	// Unicode in UNICOWS mode to be used on NT only from 3.5 build 711
 		SendMsg( SB_SETTEXTW, part, reinterpret_cast<LPARAM>(str) );
 	}

--- a/kilib/file.cpp
+++ b/kilib/file.cpp
@@ -79,7 +79,7 @@ static HANDLE CreateFileUNC(
 	TCHAR *UNCPath = (TCHAR *)fname;
 #ifdef UNICODE
 	// UNC are supported only un Unicode mode on Windows NT
-	if( App::isNT() )
+	if( app().isNT() )
 	{
 		UNCPath = GetUNCPath(fname);
 		if( !UNCPath ) // Failed then fallback to non UNC
@@ -109,7 +109,7 @@ DWORD GetFileAttributesUNC(LPCTSTR fname)
 	TCHAR *UNCPath = (TCHAR *)fname;
 #ifdef UNICODE
 	// UNC are supported only un Unicode mode on Windows NT
-	if( App::isNT() )
+	if( app().isNT() )
 	{
 		UNCPath = GetUNCPath(fname);
 		if( !UNCPath ) // Failed then fallback to non UNC
@@ -152,7 +152,14 @@ bool FileR::Open( const TCHAR* fname, bool always)
 		FILE_ATTRIBUTE_NORMAL|FILE_FLAG_SEQUENTIAL_SCAN, NULL
 	);
 	if( handle_ == INVALID_HANDLE_VALUE )
+	{
+		#ifdef _DEBUG
+		TCHAR msg[300];
+		::wsprintf( msg, TEXT("CreateFile(%s) failed #%d"), fname, ::GetLastError() );
+		::MessageBox( NULL,msg,TEXT("Debug"),0 );
+		#endif
 		return false;
+	}
 
 	// ƒTƒCƒY‚ðŽæ“¾
 	size_ = ::GetFileSize( handle_, NULL );
@@ -169,6 +176,11 @@ bool FileR::Open( const TCHAR* fname, bool always)
 			handle_, NULL, PAGE_READONLY, 0, 0, NULL );
 		if( fmo_ == NULL )
 		{
+			#ifdef _DEBUG
+			TCHAR msg[300];
+			::wsprintf( msg, TEXT("CreateFileMapping(%s) failed #%d"), fname, ::GetLastError() );
+			::MessageBox( NULL,msg,TEXT("Debug"),0 );
+			#endif
 			::CloseHandle( handle_ );
 			handle_ = INVALID_HANDLE_VALUE;
 			return false;
@@ -178,7 +190,13 @@ bool FileR::Open( const TCHAR* fname, bool always)
 		basePtr_ = ::MapViewOfFile( fmo_, FILE_MAP_READ, 0, 0, 0 );
 		if( basePtr_ == NULL )
 		{
+			#ifdef _DEBUG
+			TCHAR msg[300];
+			::wsprintf( msg, TEXT("MapViewOfFile(%s) failed #%d"), fname, ::GetLastError() );
+			::MessageBox( NULL,msg,TEXT("Debug"),0 );
+			#endif
 			::CloseHandle( fmo_ );
+			fmo_ = NULL;
 			::CloseHandle( handle_ );
 			handle_ = INVALID_HANDLE_VALUE;
 			return false;
@@ -236,7 +254,7 @@ bool FileW::Open( const TCHAR* fname, bool creat )
 	TCHAR *UNCPath = (TCHAR *)fname;
 #ifdef UNICODE
 	// UNC are supported only un Unicode mode on Windows NT
-	if( App::isNT() )
+	if( app().isNT() )
 		UNCPath = GetUNCPath(fname);
 	if( !UNCPath ) // Failed then fallback to non UNC
 		UNCPath = (TCHAR *)fname;

--- a/kilib/log.cpp
+++ b/kilib/log.cpp
@@ -28,8 +28,11 @@ void Logger::WriteLine( const TCHAR* str, int siz )
 
 	// ファイル名
 	TCHAR fname[MAX_PATH];
+	// GetModuleFileName() fails with NULL hInstance on Win32s before 1.25
 	::GetModuleFileName( ::GetModuleHandle(NULL), fname, countof(fname) );
-	::lstrcat( fname, TEXT("_log") );
+	dummy = my_lstrlen(fname);
+	fname[dummy-4] = 0;
+	my_lstrcpy( &fname[dummy-4], TEXT(".log") );
 
 	// ファイルを書き込み専用で開く
 	HANDLE h = ::CreateFile( fname,

--- a/kilib/memory.h
+++ b/kilib/memory.h
@@ -58,8 +58,6 @@ public:
 	//@{ ƒƒ‚ƒŠ‰ğ•ú //@}
 	void DeAlloc( void* ptr, size_t siz );
 
-	void* ReAlloc( void* ptr, size_t siz );
-
 #ifdef USE_ORIGINAL_MEMMAN
 private:
 	struct FixedSizeMemBlockPool

--- a/kilib/path.cpp
+++ b/kilib/path.cpp
@@ -117,7 +117,7 @@ Path& Path::BeShortStyle()
 #if defined(UNICOWS) || !defined(TARGET_VER) || (defined(TARGET_VER) && TARGET_VER>=350)
 // In UNICOWS mode the A/W functions are imported dynamically anyway.
 // GetShortPathName needs at least 95/NT4 but there is a stub in NT3.5
-	if(app().isNewShell()) // 95/NT4+
+	if( app().isNewShell() ) // 95/NT4+
 	{
 		TCHAR* buf = ReallocMem( len()+1 );
 		::GetShortPathName( buf, buf, len()+1 );

--- a/kilib/path.h
+++ b/kilib/path.h
@@ -121,7 +121,8 @@ public:
 //-------------------------------------------------------------------------
 
 inline bool Path::isFile() const
-	{ return 0==(GetFileAttributesUNC(c_str())&FILE_ATTRIBUTE_DIRECTORY); }
+	{ return c_str()[len()-1] != TEXT('\\') && c_str()[len()-1] != TEXT('/')
+	      && 0==(GetFileAttributesUNC(c_str())&FILE_ATTRIBUTE_DIRECTORY); }
 
 inline bool Path::isDirectory() const
 	{ DWORD x=GetFileAttributesUNC(c_str());

--- a/kilib/string.cpp
+++ b/kilib/string.cpp
@@ -64,7 +64,7 @@ wchar_t * WINAPI my_CharLowerWW(wchar_t *s)
 wchar_t my_CharUpperSingleW(wchar_t c)
 {
 #if defined(UNICOWS) || !defined(_UNICODE)
-	if( App::isNT() )
+	if( app().isNT() )
 		return (wchar_t)(LONG_PTR)::CharUpperW( (wchar_t *)(LONG_PTR)c );
 	else
 		return SingleCharUpperW_nonNT(c);
@@ -75,7 +75,7 @@ wchar_t my_CharUpperSingleW(wchar_t c)
 wchar_t my_CharLowerSingleW(wchar_t c)
 {
 #if defined(UNICOWS) || !defined(_UNICODE)
-	if( App::isNT() )
+	if( app().isNT() )
 		return (wchar_t)(LONG_PTR)::CharLowerW( (wchar_t *)(LONG_PTR)c );
 	else
 		return SingleCharLowerW_nonNT(c);
@@ -95,7 +95,7 @@ static BOOL my_IsCharLowerW_nonNT(wchar_t c)
 BOOL my_IsCharLowerW(wchar_t c)
 {
 #if defined(UNICOWS) || !defined(_UNICODE)
-	if( App::isNT() )
+	if( app().isNT() )
 		return ::IsCharLowerW( c );
 	else
 		return my_IsCharLowerW_nonNT(c);
@@ -105,6 +105,53 @@ BOOL my_IsCharLowerW(wchar_t c)
 
 }
 
+#ifdef OLDWIN32S
+int SimpleWC2MB(UINT cp, DWORD flg, LPCWSTR s, int sl, LPSTR d, int dl, LPCSTR defc, LPBOOL useddef)
+{
+	if( d == NULL || dl == 0 ) // return required length.
+		return sl==-1? my_lstrlenW(s): sl;
+
+	int i;
+	if( sl == -1 )
+	{ // Copy until NULL
+		for( i=0; i < dl && s[i]; i++)
+			d[i] = (char)s[i];
+		d[i] = '\0';
+		return i == dl? 0: i;
+	}
+
+	if( dl <= sl )
+		return 0;
+
+	for( i=0; i < sl; i++)
+		d[i] = (char)s[i];
+
+	d[i] = '\0';
+	return i;
+}
+int WINAPI SimpleMB2WC(UINT cp, DWORD flg, LPCSTR s, int sl, LPWSTR d, int dl)
+{
+	if( d == NULL || dl == 0 )
+		return sl==-1? my_lstrlenA(s): sl;
+
+	int i;
+	if( sl == -1 )
+	{ // Copy until NULL
+		for( i=0; i < dl && s[i]; i++)
+			d[i] = (wchar_t)s[i];
+		d[i] = L'\0';
+		return i == dl? 0: i;
+	}
+
+	if( dl <= sl )
+		return 0;
+
+	for( i=0; i < sl; i++)
+		d[i] = (char)s[i];
+	d[i] = L'\0';
+	return i;
+}
+#endif// OLDWIN32S
 
 //=========================================================================
 String::StringData* String::nullData_;

--- a/kilib/string.h
+++ b/kilib/string.h
@@ -22,6 +22,13 @@
 	#define my_lstrcat my_lstrcatA
 #endif
 
+#ifdef OLDWIN32S
+int WINAPI SimpleMB2WC(UINT cp, DWORD flg, LPCSTR s, int sl, LPWSTR d, int dl);
+int SimpleWC2MB(UINT cp, DWORD flg, LPCWSTR s, int sl, LPSTR d, int dl, LPCSTR defc, LPBOOL useddef);
+#define WideCharToMultiByte SimpleWC2MB
+#define MultiByteToWideChar SimpleMB2WC
+#endif
+
 wchar_t * WINAPI my_CharUpperWW(wchar_t *s);
 wchar_t * WINAPI my_CharLowerWW(wchar_t *s);
 #define my_CharUpperW my_CharUpperWW

--- a/kilib/textfile.cpp
+++ b/kilib/textfile.cpp
@@ -821,9 +821,9 @@ namespace
 		// It seems CharNextExA can crash
 		// so we exclude NT versions between 3.51.1057 and  and 4.00.1381
 		uNextFunc Window_CharNextExA = (uNextFunc)NULL ;
-		if(!App::isNT()
-		||  App::isNTOSVerEqual( 351, 1057 )
-		||  App::isNTOSVerLarger( 400, 1381 ) )
+		if(!app().isNT()
+		||  app().isNTOSVerEqual( MKVER(3,51,1057) )
+		||  app().isNTOSVerLarger( MKVER(4,00,1381) ) )
 		{
 			Window_CharNextExA = (uNextFunc)GetProcAddress(GetModuleHandleA("USER32.DLL"), "CharNextExA");
 			if (Window_CharNextExA)

--- a/kilib/window.cpp
+++ b/kilib/window.cpp
@@ -48,9 +48,9 @@ static bool LoadIMM32DLL()
 {
 	// Don't even try on Win32S because when LoadLibrary()
 	// fails we get an error message
-	if( App::isWin32s() )
+	if( app().isWin32s() )
 		return false;
-//	if ( !::GetSystemMetrics(SM_DBCSENABLED) && App::getOSVer() >= 500 && !::GetSystemMetrics(/*SM_IMMENABLED*/ 82) )
+//	if ( !::GetSystemMetrics(SM_DBCSENABLED) && app().getOOSVer() >= 0x05000000 && !::GetSystemMetrics(/*SM_IMMENABLED*/ 82) )
 //		return false;
 
 	//MessageBox(NULL, TEXT("Going to Load IMM32.DLL"), NULL, 0);
@@ -161,7 +161,7 @@ IMEManager::IMEManager()
 		// No global IME on Win95 because it is buggy...
 		// RamonUnch: I found it is not so buggy so
 		// I re-enabled it unless we are on a DBCS enabled system!
-		if( app().getOSVer() >= 400 && !( app().isWin95() && ::GetSystemMetrics(SM_DBCSENABLED) ) )
+		if( app().getOOSVer() >= 0x04000000 && !( app().isWin95() && ::GetSystemMetrics(SM_DBCSENABLED) ) )
 		{ // Not available on Win32s/NT3.X?
 			app().InitModule( App::OLE );
 			if( S_OK == ::MyCoCreateInstance(


### PR DESCRIPTION
1) Avoid static member functions ad use const
2) Simplify version comparison bu using an ordered version DWORD (MMmmBBBB) (Major, minior, Build) so that version can be compared with a single operation instead of three.
3) Refactor the rest of the code:
 a. use app().function() instead of App::function() because member are no longer static
 b. functions were modified to be simpler so the calling convention has changed