### PR TITLE
Various fixes to OpenDialog and reopen dialog

### DIFF
--- a/GpMain.h
+++ b/GpMain.h
@@ -70,7 +70,7 @@ private:
 private:
 
 	bool isUntitled() const { return filename_.len()==0; }
-	int resolvedCSI();
+	int resolveCSI(int csi) const ;
 
 private:
 


### PR DESCRIPTION
On Windows 95 4.00.116 we cannot add the cs drop list.
As a safety I just allow the new style open dialog on RTM version of 95/NT4.
The error checking was reordered.
Also the reopen dialog was improved wen using an unlisted cp.