### PR TITLE
Optimize file loading time

### DIFF
--- a/ConfigManager.cpp
+++ b/ConfigManager.cpp
@@ -504,7 +504,7 @@ void ConfigManager::LoadLayout( ConfigManager::DocType* dt )
 
 		// Read the whole file at once.
 		unicode buf[1024], *nptr=buf,*ptr;
-		size_t len = tf.ReadLine( buf, countof(buf)-8 );
+		size_t len = tf.ReadBuf( buf, countof(buf)-8 );
 		buf[len] = L'\0'; // NULL terminate in case.
 		for( ptr=buf; ptr<buf+len; ptr=nptr ) // !EOF
 		{
@@ -513,7 +513,6 @@ void ConfigManager::LoadLayout( ConfigManager::DocType* dt )
 				nptr++;
 			*nptr++ = L'\0'; // zero out endline.
 			nptr += *(nptr) == L'\n'; // Skip eventual \n
-			LOGGERS( ptr );
 
 			if( nptr-ptr < 3 || ptr[0] == L';' || ptr[2] != L'=' )
 				continue;

--- a/ConfigManager.cpp
+++ b/ConfigManager.cpp
@@ -502,15 +502,26 @@ void ConfigManager::LoadLayout( ConfigManager::DocType* dt )
 		bool   clfound = false;
 		dt->fontCS = DEFAULT_CHARSET;
 
-		unicode buf[1024], *ptr=buf+3;
-		while( tf.state() != 0 ) // !EOF
+		// Read the whole file at once.
+		unicode buf[1024], *nptr=buf,*ptr;
+		size_t len = tf.ReadLine( buf, countof(buf)-8 );
+		buf[len] = L'\0'; // NULL terminate in case.
+		for( ptr=buf; ptr<buf+len; ptr=nptr ) // !EOF
 		{
-			size_t len = tf.ReadLine( buf, countof(buf)-1 );
-			if( len<=3 || buf[0] == L';' || buf[2]!=L'=' )
-				continue;
-			buf[len] = L'\0';
+			// Get to next line
+			while( *nptr != L'\0' &&  *nptr != L'\r' && *nptr != L'\n' )
+				nptr++;
+			*nptr++ = L'\0'; // zero out endline.
+			nptr += *(nptr) == L'\n'; // Skip eventual \n
+			LOGGERS( ptr );
 
-			switch( (buf[0]<<8)|buf[1] ) // ASCII only
+			if( nptr-ptr < 3 || ptr[0] == L';' || ptr[2] != L'=' )
+				continue;
+
+			unicode XXoption = (ptr[0]<<8) | ptr[1];
+			ptr += 3; // go just after the = sign
+
+			switch( XXoption ) // ASCII only
 			{
 			case 0x6374: // ct: COLOR-TEXT
 				dt->vc.color[TXT] = GetColor(ptr);

--- a/editwing/ip_text.cpp
+++ b/editwing/ip_text.cpp
@@ -752,7 +752,7 @@ void DocImpl::OpenFile( aptr<TextFileR> tf )
 	}
 	for( ulong i=0; tf->state(); )
 	{
-		if( size_t L = tf->ReadLine( buf, buf_sz ) )
+		if( size_t L = tf->ReadBuf( buf, buf_sz ) )
 		{
 			DPos p(i,0xffffffff);
 			InsertingOperation( p, buf, (ulong)L, e );

--- a/kilib/textfile.cpp
+++ b/kilib/textfile.cpp
@@ -956,17 +956,12 @@ struct rMBCS : public TextFileRPimpl
 	{
 		// バッファの終端か、ファイルの終端の近い方まで読み込む
 		// Read to the end of the buffer or near the end of the file
-		const char *p, *end = Min( fb+siz/2, fe );
+		const char *p, *end = Min( fb+siz/2-2, fe );
 		state = (end==fe ? EOF : EOB);
 
 		// 改行が出るまで進む,  Proceed until the line breaks.
 		for( p=fb; p<end; )
-			if( *p=='\r' || *p=='\n' )
-			{
-				state = EOL;
-				break;
-			}
-			else if( (*p) & 0x80 && p+1<fe )
+			if( (*p) & 0x80 && p+1<fe )
 			{
 				p = next(cp,p,0);
 			}
@@ -975,14 +970,15 @@ struct rMBCS : public TextFileRPimpl
 				++p;
 			}
 
+		if( *(p-1)=='\r' && *(p) =='\n' )
+		{ // DOS line ending, skip the '\n' too.
+			++p;
+		}
+
 		// Unicodeへ変換, convertion to Unicode
 		ulong len;
 		len = conv( cp, 0, fb, p-fb, buf, siz );
 
-		// 改行コードスキップ処理, Newline code skipping process
-		if( state == EOL )
-			if( *(p++)=='\r' && p<fe && *p=='\n' )
-				++p;
 		fb = p;
 
 		// 終了

--- a/kilib/textfile.cpp
+++ b/kilib/textfile.cpp
@@ -67,6 +67,7 @@ struct rBasicUTF : public ki::TextFileRPimpl
 			if(BOF) BOF = false;
 		}
 
+		// If the end of the buffer contains half a DOS CRLF
 		if( *(w-1)==L'\r' && PeekC() == L'\n' )
 			Skip();
 
@@ -964,10 +965,9 @@ struct rMBCS : public TextFileRPimpl
 				++p;
 			}
 
+		// If the end of the buffer contains half a DOS CRLF
 		if( *(p-1)=='\r' && *(p) =='\n' )
-		{ // DOS line ending, skip the '\n' too.
 			++p;
-		}
 
 		// Unicode‚Ö•ÏŠ·, convertion to Unicode
 		ulong len;
@@ -1178,7 +1178,8 @@ struct rIso2022 : public TextFileRPimpl
 			}
 		outofloop:
 
-		if( *(p-1)=='\r' && p<fe && *p=='\n' )
+		// If the end of the buffer contains half a DOS CRLF
+		if( *(p-1)=='\r' && *p=='\n' )
 			++p;
 		fb = p;
 

--- a/kilib/textfile.cpp
+++ b/kilib/textfile.cpp
@@ -25,7 +25,7 @@ struct ki::TextFileRPimpl : public Object
 	inline TextFileRPimpl()
 		: state(EOL) {}
 
-	virtual size_t ReadLine( unicode* buf, ulong siz )
+	virtual size_t ReadBuf( unicode* buf, ulong siz )
 		= 0;
 
 	enum { EOF=0, EOL=1, EOB=2 } state;
@@ -48,7 +48,7 @@ struct rBasicUTF : public ki::TextFileRPimpl
 
 	bool BOF;
 
-	size_t ReadLine( unicode* buf, ulong siz )
+	size_t ReadBuf( unicode* buf, ulong siz )
 	{
 		state = EOF;
 
@@ -947,7 +947,7 @@ struct rMBCS : public TextFileRPimpl
 			fb += 3; // BOMスキップ
 	}
 
-	size_t ReadLine( unicode* buf, ulong siz )
+	size_t ReadBuf( unicode* buf, ulong siz )
 	{
 		// バッファの終端か、ファイルの終端の近い方まで読み込む
 		// Read to the end of the buffer or near the end of the file
@@ -1143,7 +1143,7 @@ struct rIso2022 : public TextFileRPimpl
 		len+=wt;
 	}
 
-	size_t ReadLine( unicode* buf, ulong siz )
+	size_t ReadBuf( unicode* buf, ulong siz )
 	{
 		len=0;
 
@@ -1205,9 +1205,9 @@ TextFileR::~TextFileR()
 	Close();
 }
 
-size_t TextFileR::ReadLine( unicode* buf, ulong siz )
+size_t TextFileR::ReadBuf( unicode* buf, ulong siz )
 {
-	return impl_->ReadLine( buf, siz );
+	return impl_->ReadBuf( buf, siz );
 }
 
 int TextFileR::state() const

--- a/kilib/textfile.h
+++ b/kilib/textfile.h
@@ -173,7 +173,7 @@ public:
 	//
 	//	少なくとも20くらいのサイズを確保したバッファを指定してください。
 	//@}
-	size_t ReadLine( unicode* buf, ulong siz );
+	size_t ReadBuf( unicode* buf, ulong siz );
 
 public:
 


### PR DESCRIPTION
For now GreenPad reads the file line by line, this is hugely inefficient and forces the use of CreateFileMapping (or it would be crazy slow).

The idea is to use the fact that InsertingOperation() can handle multi-line buffer, so we can read a big buffer at once, which will be much faster. I already got form 28s to 15s to load a big test file (Latin1).

I just need to test more carefully and to apply the same logic to all ReadLine functions.

The question is: Why did k.inaba made this line by line reading that is actually more complex and much slower? Am I missing something?

This is also a necessary step to use piping with uconf.exe later, otherwise overhead would be too large.


* Progress on : #14
* Progress on: #60

@roytam1 You might be interested by this patch, I did very little testing, I will try to make some regression testing for this, If you could double-check it would be great (whenever you got spare time of course).