### PR TITLE
Add an OldOpenSaveDlg ini option

### DIFF
--- a/ConfigManager.cpp
+++ b/ConfigManager.cpp
@@ -784,6 +784,8 @@ void ConfigManager::LoadIni()
 	}
 	// Exit with the ESC key?
 	useQuickExit_ = ini_.GetBool( TEXT("QuickExit"), false );
+	// Exit with the ESC key?
+	useOldOpenSaveDlg_ = ini_.GetBool( TEXT("OldOpenSaveDlg"), false );
 
 	// Print Margins
 	SetRect(&rcPMargins_, 500, 500, 500, 500);

--- a/ConfigManager.cpp
+++ b/ConfigManager.cpp
@@ -784,7 +784,7 @@ void ConfigManager::LoadIni()
 	}
 	// Exit with the ESC key?
 	useQuickExit_ = ini_.GetBool( TEXT("QuickExit"), false );
-	// Exit with the ESC key?
+	// Use the old Windows 3.x Open/Save dialog style?
 	useOldOpenSaveDlg_ = ini_.GetBool( TEXT("OldOpenSaveDlg"), false );
 
 	// Print Margins

--- a/ConfigManager.h
+++ b/ConfigManager.h
@@ -119,6 +119,7 @@ public:
 	const RECT *PMargins() const;
 	void SetPrintMargins(const RECT *rc);
 	bool useQuickExit() const;
+	bool useOldOpenSaveDlg() const;
 
 private:
 
@@ -139,6 +140,7 @@ private:
 	bool       rememberWindowSize_;
 	bool       rememberWindowPlace_;
 	bool       useQuickExit_;
+	bool       useOldOpenSaveDlg_;
 
 	ki::String dateFormat_;
 //	ki::String timeFormat_;
@@ -283,6 +285,10 @@ inline void ConfigManager::SetPrintMargins(const RECT *rc)
 
 inline bool ConfigManager::useQuickExit() const
 	{ return useQuickExit_; }
+
+inline bool ConfigManager::useOldOpenSaveDlg() const
+	{ return useOldOpenSaveDlg_; }
+
 //=========================================================================
 
 #endif // __ccdoc__

--- a/GpMain.cpp
+++ b/GpMain.cpp
@@ -1357,7 +1357,7 @@ bool GreenPadWnd::ShowOpenDlg( Path* fn, int* cs )
 	};
 	aarr<TCHAR> filt = OpenFileDlg::ConnectWithNull(flst, countof(flst));
 
-	OpenFileDlg ofd( charSets_ );
+	OpenFileDlg ofd( charSets_, cfg_.useOldOpenSaveDlg() );
 	bool ok = ofd.DoModal( hwnd(), filt.get(), filename_.c_str() );
 	if( ok )
 	{
@@ -1565,7 +1565,7 @@ bool GreenPadWnd::ShowSaveDlg()
 	};
 	aarr<TCHAR> filt = SaveFileDlg::ConnectWithNull( flst, countof(flst) );
 
-	SaveFileDlg sfd( charSets_, csi_, lb_ );
+	SaveFileDlg sfd( charSets_, csi_, lb_, cfg_.useOldOpenSaveDlg() );
 	stb_.SetText( TEXT("Saving file...") );
 	if( !sfd.DoModal( hwnd(), filt.get(), filename_.c_str() ) )
 		return false;

--- a/OpenSaveDlg.cpp
+++ b/OpenSaveDlg.cpp
@@ -368,7 +368,7 @@ bool OpenFileDlg::DoModal( HWND wnd, const TCHAR* fltr, const TCHAR* fnm )
 
 	// On Windows 95 4.00.116 we cannot add the cs droplist.
 	// Only use the New style dialog on Win95 347+/NT4 RTM.
-	if( app().isNewOpenSaveDlg() )
+	if(  !oldstyleDlg_ && app().isNewOpenSaveDlg() )
 	{
 		// Include the OFN_EXPLORER flag to get the new look.
 		ofn.Flags |= OFN_EXPLORER;
@@ -553,7 +553,7 @@ bool SaveFileDlg::DoModal( HWND wnd, const TCHAR* fltr, const TCHAR* fnm )
 				OFN_OVERWRITEPROMPT;
 
 
-	if( app().isNewOpenSaveDlg() )
+	if( !oldstyleDlg_ && app().isNewOpenSaveDlg() )
 	{
 		// Include the OFN_EXPLORER flag to get the new look.
 		ofn.Flags |= OFN_EXPLORER;

--- a/OpenSaveDlg.h
+++ b/OpenSaveDlg.h
@@ -57,7 +57,7 @@ private:
 class OpenFileDlg
 {
 public:
-	explicit OpenFileDlg( const CharSetList& csl );
+	explicit OpenFileDlg( const CharSetList& csl, bool oldstyle );
 	bool DoModal( HWND wnd, const TCHAR* filter, const TCHAR* fnm );
 
 public:
@@ -72,6 +72,7 @@ private:
 	TCHAR filename_[MAX_PATH];
 	int   csIndex_;
 	bool  dlgEverOpened_;
+	bool  oldstyleDlg_;
 
 private:
 	static OpenFileDlg* pThis; // マルチスレッド禁止！
@@ -83,8 +84,8 @@ private:
 //------------------------------------------------------------------------
 #ifndef __ccdoc__
 
-inline OpenFileDlg::OpenFileDlg( const CharSetList& csl )
-	: csl_(csl) {}
+inline OpenFileDlg::OpenFileDlg( const CharSetList& csl, bool oldstyle )
+	: csl_(csl), oldstyleDlg_(oldstyle) {}
 
 inline const TCHAR* OpenFileDlg::filename() const
 	{ return filename_; }
@@ -107,7 +108,7 @@ inline int OpenFileDlg::csi() const
 class SaveFileDlg
 {
 public:
-	explicit SaveFileDlg( const CharSetList& csl, int cs, int lb );
+	explicit SaveFileDlg( const CharSetList& csl, int cs, int lb, bool oldstyle );
 	bool DoModal( HWND wnd, const TCHAR* filter, const TCHAR* fnm );
 
 public:
@@ -124,6 +125,7 @@ private:
 	int   csIndex_;
 	int   lb_;
 	bool  dlgEverOpened_;
+	bool  oldstyleDlg_;
 
 private:
 	static SaveFileDlg* pThis; // マルチスレッド禁止！
@@ -133,8 +135,8 @@ private:
 //------------------------------------------------------------------------
 #ifndef __ccdoc__
 
-inline SaveFileDlg::SaveFileDlg( const CharSetList& csl, int cs, int lb )
-	: csl_(csl), csIndex_(cs), lb_(lb) {}
+inline SaveFileDlg::SaveFileDlg( const CharSetList& csl, int cs, int lb, bool oldstyle )
+	: csl_(csl), csIndex_(cs), lb_(lb), oldstyleDlg_(oldstyle) {}
 
 inline const TCHAR* SaveFileDlg::filename() const
 	{ return filename_; }


### PR DESCRIPTION
So that the user can choose which dialog he prefers. Plus on Windows 9x the new style explorer dialog is less stable.
Also improves upon #83.