### PR TITLE
Fix signed-unsigned compare in CharNextGB18030()

### DIFF
--- a/kilib/kstring.h
+++ b/kilib/kstring.h
@@ -138,6 +138,15 @@ int my_lstrcmpA(const char *X, const char *Y)
 	return *(const unsigned char*)X - *(const unsigned char*)Y;
 }
 
+#define tolowerASCII(x) ( (x) | ('A'<(x) && (x)<'Z') << 5 )
+static inline
+int my_lstrcmpiASCII(const char *X, const char *Y)
+{
+	while ( *X && tolowerASCII(*X) == tolowerASCII(*Y) ) { X++; Y++; }
+	return tolowerASCII( *(const unsigned char*)X )
+	     - tolowerASCII( *(const unsigned char*)Y );
+}
+
 static inline
 wchar_t *my_lstrcpynW(wchar_t *out, const wchar_t *in, int outlen)
 {
@@ -251,7 +260,7 @@ public:
 	size_t len() const;
 
 	//@{ óvëf //@}
-	const TCHAR operator[](int n) const;
+	TCHAR operator[](int n) const;
 
 	//@{ ÉèÉCÉhï∂éöóÒÇ…ïœä∑ÇµÇƒï‘Ç∑ //@}
 	const wchar_t* ConvToWChar() const;
@@ -375,7 +384,7 @@ inline const TCHAR* String::c_str() const
 inline size_t String::len() const
 	{ return data_->len-1; }
 // óvëf
-inline const TCHAR String::operator[](int n) const
+inline TCHAR String::operator[](int n) const
 	{ return data_->buf()[n]; }
 
 // î‰är


### PR DESCRIPTION
and minor refactor to chardetAutoDetection
Also uchar <= 0xFF does nothing.
Same for 0x00 <= uchar

Same for unicode c<0 || c>0x10ffff (is always true).

The important fixes are in `CharNextGB18030()` were char == 0x80 can be dropped by the compiler because after integer promotion, the result is always false. same for char == 0xFF.

So we must always work on uchars.
