### PR TITLE
Improve Saving stuff

### DIFF
--- a/kilib/file.h
+++ b/kilib/file.h
@@ -96,6 +96,9 @@ public:
 	//@{ ˆê•¶š‘‚­ //@}
 	void WriteC( const uchar ch );
 
+	//@{ Writes to the file using a specific output codepage //@}
+	void WriteInCodepageFromUnicode( int cp, const unicode* str, ulong len );
+
 public:
 
 	void Flush();

--- a/kilib/textfile.cpp
+++ b/kilib/textfile.cpp
@@ -1570,9 +1570,7 @@ int TextFileR::MLangAutoDetection( const uchar* ptr, ulong siz )
 		}
 
 	# ifdef MLANG_DEBUG
-		TCHAR tmp[10];
-		::wsprintf(tmp,TEXT("%d"),cs);
-		::MessageBox(NULL,tmp,TEXT("MLangDetect"),0);
+		::MessageBox(NULL, SInt2Str(cs),TEXT("MLangDetect"),0);
 	# endif
 
 //		if (cs == 20127) cs = 0; // 20127 == ASCII, 0 = unknown
@@ -1725,7 +1723,7 @@ int TextFileR::chardetAutoDetection( const uchar* ptr, ulong siz )
 	::FreeLibrary(hIL);
 
 	#ifdef MLANG_DEBUG
-	::MessageBox(NULL,cs? TEXT("Chardet sucess!"): TEXT("Detection failed") ,TEXT("CHARDET"),0);
+	::MessageBox(NULL, SInt2Str(cs), TEXT("CHARDET"),0);
 	#endif
 
 #endif //NO_CHARDET
@@ -2187,7 +2185,7 @@ protected:
 };
 
 //#define WBUF_SIZE 16 // Test with a super small buffer for debugging.
-#define WBUF_SIZE 32768
+#define WBUF_SIZE 8192
 struct TextFileWPimplWithBuf: public ki::TextFileWPimpl
 {
 	TextFileWPimplWithBuf( FileW& w )


### PR DESCRIPTION
1. Separate TextFileWPimplWithBuf that derives from TextFileWPimpl, because most saving routines are not depending on an intermediate buffer.
2. Make generic ReadLine() implementation from ReadBuf with limited buffer size.
3. Get rid of all crazy realloc stuff, much simpler and safer and faster when saving a file with a Huge line.
4. Avoid intermediate buffer when making a simple WideCharToMultibyte convertion and instead directly use the file buffer.
5. Reduce file buffer a little because it is not slower with 32kB and slightly slower with 1KB, but much slower with 128KB. Maybe even lower values could make sense.