### PR TITLE
Improve rMBCS

### DIFF
--- a/kilib/textfile.cpp
+++ b/kilib/textfile.cpp
@@ -887,7 +887,7 @@ struct rMBCS A_FINAL: public TextFileRPimpl
 		, fe( reinterpret_cast<const char*>(b+s) )
 		, cp( c==UTF8 ? UTF8N : c )
 		, next( GetCharNextExA( cp ) )
-		, conv( cp==UTF8N /*&& (app().isWin95()||!::IsValidCodePage(65001)) */
+		, conv( cp==UTF8N && (app().isWin95()||!::IsValidCodePage(65001))
 		                  ? Utf8ToWideChar : MultiByteToWideChar )
 	{
 		if( cp==UTF8N && fe-fb>=3


### PR DESCRIPTION
Make use of the GetCPInfo() to fill up a next_LUT[] table, much faster to lookup than to call CharNextExA
Also GetCPInfo is present since Windows NT 3.1, works on Win32s as well.

There is still a problem With GB18030 Next function, because it might read bytes beyond the end of file if the ending sequence is invalid. The code should be inlined in the next() loop and fine-tuned for oob read through fb.

I wonder if there are other code-pages that have a multi-byte sequence longer than 2.
EDIT there are just on my system:
```
CP50220 Has MaxCharSize=5
CP50221 Has MaxCharSize=5
CP50222 Has MaxCharSize=5
CP50225 Has MaxCharSize=5
CP50227 Has MaxCharSize=5
CP50229 Has MaxCharSize=5
CP52936 Has MaxCharSize=5
-- CP54936 Has MaxCharSize=4 /GB18030
CP57002 Has MaxCharSize=4
CP57003 Has MaxCharSize=4
CP57004 Has MaxCharSize=4
CP57005 Has MaxCharSize=4
CP57006 Has MaxCharSize=4
CP57007 Has MaxCharSize=4
CP57008 Has MaxCharSize=4
CP57009 Has MaxCharSize=4
CP57010 Has MaxCharSize=4
CP57011 Has MaxCharSize=4
-- CP65000 Has MaxCharSize=5 /UTF-7
-- CP65001 Has MaxCharSize=4 /UTF-8
`