### PR TITLE
Improve writing performances

### DIFF
--- a/kilib/file.h
+++ b/kilib/file.h
@@ -96,6 +96,14 @@ public:
 	//@{ ˆê•¶š‘‚­ //@}
 	void WriteC( const uchar ch );
 
+	//@{ Write a character without checking bufer //@}
+	inline void WriteCN( const uchar ch )
+		{ buf_[bPos_++] = ch; }
+
+	//@{ Flush if needed to get the specified space //@}
+	inline void NeedSpace( const ulong sz )
+		{ if( (BUFSIZE-bPos_) <= sz ) Flush(); }
+
 	//@{ Writes to the file using a specific output codepage //@}
 	void WriteInCodepageFromUnicode( int cp, const unicode* str, ulong len );
 
@@ -114,7 +122,6 @@ private:
 
 	NOCOPY(FileW);
 };
-
 
 //=========================================================================
 


### PR DESCRIPTION
Add FileW::WriteCN() that do not check for flushing
Add FileW::NeedSpace() to manualy flush if needed making sure enough space remain at the end of the buffer.
Unroll some loops, (huge speed up in some cases)
re-order some branches so that high/low surrogate checks and calculations are done after other simpler checks that will occur more often.
