### PR TITLE
pass by ref for DrawTXT() and by const for event stuff

### DIFF
--- a/editwing/ewView.h
+++ b/editwing/ewView.h
@@ -231,7 +231,7 @@ public:
 	Cursor( HWND wnd, ViewImpl& vw, doc::DocImpl& dc );
 	~Cursor();
 	void AddHandler( CurEvHandler* ev );
-	void DelHandler( CurEvHandler* ev );
+	void DelHandler( const CurEvHandler* ev );
 
 	// ƒJ[ƒ\ƒ‹ˆÚ“®
 	void MoveCur( const DPos& dp, bool select );

--- a/editwing/ip_cursor.cpp
+++ b/editwing/ip_cursor.cpp
@@ -161,7 +161,7 @@ void Cursor::AddHandler( CurEvHandler* ev )
 	pEvHan_ = ev;
 }
 
-void Cursor::DelHandler( CurEvHandler* ev )
+void Cursor::DelHandler( const CurEvHandler* ev )
 {
 	if( ev == pEvHan_ )
 		pEvHan_ = &defaultHandler_;

--- a/editwing/ip_draw.cpp
+++ b/editwing/ip_draw.cpp
@@ -767,7 +767,7 @@ inline void ViewImpl::Inv( int y, int xb, int xe, Painter& p )
 	p.Invert( rc );
 }
 
-void ViewImpl::DrawTXT( const VDrawInfo v, Painter& p )
+void ViewImpl::DrawTXT( const VDrawInfo &v, Painter& p )
 {
 	// ’è”‚P, Constant 1
 //	const int   TAB = p.T();

--- a/editwing/ip_view.h
+++ b/editwing/ip_view.h
@@ -462,7 +462,7 @@ private:
 private:
 
 	void DrawLNA( const VDrawInfo& v, Painter& p );
-	void DrawTXT( const VDrawInfo v, Painter& p );
+	void DrawTXT( const VDrawInfo& v, Painter& p );
 	void Inv( int y, int xb, int xe, Painter& p );
 
 	void CalcEveryLineWidth();


### PR DESCRIPTION
...Saves exe space and faster drawing (presumably).

DelHandler can get CurEvHandler by const

void ViewImpl::DrawTXT() should take VDrawInfo by ref!!!