### PR TITLE
auto_pointer to unique_pointer

### DIFF
--- a/RSearch.cpp
+++ b/RSearch.cpp
@@ -125,13 +125,14 @@ struct RegClass: public Object
 {
 	struct OneRange
 	{
+		OneRange( wchar_t s, wchar_t e ): stt(s), end(e) {}
 		wchar_t stt;
 		wchar_t end;
 	};
 	OneRange      range;
 	uptr<RegClass> next;
 	RegClass( wchar_t s, wchar_t e, RegClass* n )
-		{  range.stt=s, range.end=e, next.reset(n); }
+		: range( s, e ) , next( n ) {}
 };
 
 struct RegNode: public Object

--- a/RSearch.cpp
+++ b/RSearch.cpp
@@ -129,7 +129,7 @@ struct RegClass: public Object
 		wchar_t end;
 	};
 	OneRange      range;
-	aptr<RegClass> next;
+	uptr<RegClass> next;
 	RegClass( wchar_t s, wchar_t e, RegClass* n )
 		{  range.stt=s, range.end=e, next.reset(n); }
 };
@@ -152,7 +152,7 @@ struct RegNode: public Object
 	}
 	RegType           type; // このノードの種類
 	wchar_t             ch; // 文字
-	aptr<RegClass>     cls; // 文字集合
+	uptr<RegClass>     cls; // 文字集合
 	bool            cmpcls; // ↑補集合かどうか
 	RegNode          *left; // 左の子
 	RegNode         *right; // 右の子
@@ -282,7 +282,6 @@ RegNode* RegParser::reclass()
 
 	RegNode* node = new RegNode;
 	node->type   = N_Class;
-//	aptr<RegClass> ncls(cls);
 	node->cls.reset( cls );
 	node->cmpcls = neg;
 	return node;
@@ -305,7 +304,6 @@ RegNode* RegParser::primary()
 	case R_Any:{
 		node         = new RegNode;
 		node->type   = N_Class;
-//		aptr<RegClass> ncls(new RegClass( 0, 65535, NULL ));
 		node->cls.reset( new RegClass( 0, 65535, NULL ) );
 		node->cmpcls = false;
 		eat_token();
@@ -396,12 +394,12 @@ struct RegTrans : public Object
 		Class,
 		Char
 	}              type;
-	aptr<RegClass>  cls; // この文字集合
+	uptr<RegClass>  cls; // この文字集合
 	                     // orEpsilon が来たら
 	bool         cmpcls;
 	int              to; // 状態番号toの状態へ遷移
 
-	aptr<RegTrans> next; // 連結リスト
+	uptr<RegTrans> next; // 連結リスト
 /*
 	template<class Cmp>
 	bool match_i( wchar_t c, Cmp )
@@ -498,7 +496,6 @@ inline void RegNFA::add_transition
 	( int from, RegClass *cls, bool cmp, int to )
 {
 	RegTrans* x = new RegTrans;
-//	aptr<RegTrans> nn( st[from] );
 	x->next.reset( st[from] );
 	x->to    = to;
 	x->type  = RegTrans::Class;
@@ -509,14 +506,12 @@ inline void RegNFA::add_transition
 
 inline void RegNFA::add_transition( int from, wchar_t ch, int to )
 {
-//	aptr<RegClass> cls(new RegClass(ch,ch,NULL));
 	add_transition( from, new RegClass(ch,ch,NULL), false, to );
 }
 
 inline void RegNFA::add_e_transition( int from, int to )
 {
 	RegTrans* x = new RegTrans;
-//	aptr<RegTrans> nn( st[from] );
 	x->next.reset( st[from]  );
 	x->to    = to;
 	x->type  = RegTrans::Epsilon;

--- a/editwing/ip_doc.h
+++ b/editwing/ip_doc.h
@@ -420,7 +420,7 @@ public:
 
 private:
 
-	ki::aptr<Parser>                   parser_; // 文字列解析役
+	ki::uptr<Parser>                   parser_; // 文字列解析役
 	unicode                        CommentStr_[8];
 	ki::gapbufobj<Line>                text_;   // テキストデータ
 	mutable ki::storage<DocEvHandler*> pEvHan_; // イベント通知先

--- a/editwing/ip_parse.cpp
+++ b/editwing/ip_parse.cpp
@@ -735,10 +735,9 @@ void Document::SetKeyword( const unicode* defbuf, ulong siz )
 
 
 	// パーサー作成
-	aptr<Parser> np( new Parser(
+	parser_.reset( new Parser(
 		tags[0], taglen[0], tags[1], taglen[1], tags[2], taglen[2],
-		flags[1], flags[2], flags[3], flags[0] ) );
-	parser_ = np;
+		flags[1], flags[2], flags[3], flags[0] ));
 
 	// ５行目以降：キーワードリスト
 	while( !r.isEmpty() )

--- a/kilib/ktlaptr.h
+++ b/kilib/ktlaptr.h
@@ -22,44 +22,35 @@ namespace ki {
 //=========================================================================
 
 template<class T>
-class A_WUNUSED aptr
+class A_WUNUSED uptr
 {
 public:
 
 	//@{ コンストラクタ //@}
-	explicit aptr( T* p = NULL )
+	explicit uptr( T* p = NULL )
 		: obj_( p ) {}
 
 	//@{ デストラクタ //@}
-	~aptr()
+	~uptr()
 		{ delete obj_; }
 
-	//@{ 所有権移動 //@}
-//	aptr( aptr<T>& r )
-//		: obj_ ( r.release() ) {}
-//
-//	//@{ 所有権移動 //@}
-//	aptr<T>& operator=( aptr<T>& r )
-//		{
-//			if( obj_ != r.obj_ )
-//			{
-//				delete obj_;
-//				obj_ = r.release();
-//			}
-//			return *this;
-//		}
-
-	void reset( T *r )
+	//@{ Set/Reset object, (delete the old) //@} 
+	void reset( T *ptr = NULL )
 		{
-			delete obj_;
-			obj_ = r;
+		#ifdef _DEBUG
+			if( obj_ && obj_ == ptr )
+				MessageBox(NULL, TEXT("uptr::reset(): trying to reset an object to itself!"), NULL, 0);
+		#endif
+			T *old = obj_;
+			obj_ = ptr;
+			delete old;
 		}
 
-//	void move( aptr<T>& r )
-//		{
-//			delete obj_;
-//			obj_ = r.release();
-//		}
+	//@{ Transfer ownership of r to here //@} 
+	void move( uptr& r )
+		{
+			reset( r.release() );
+		}
 
 public:
 
@@ -90,7 +81,7 @@ public:
 		}
 
 private:
-	NOCOPY(aptr);
+	NOCOPY(uptr);
 	mutable T* obj_;
 };
 

--- a/kilib/ktlaptr.h
+++ b/kilib/ktlaptr.h
@@ -35,19 +35,31 @@ public:
 		{ delete obj_; }
 
 	//@{ Š—LŒ ˆÚ“® //@}
-	aptr( aptr<T>& r )
-		: obj_ ( r.release() ) {}
+//	aptr( aptr<T>& r )
+//		: obj_ ( r.release() ) {}
+//
+//	//@{ Š—LŒ ˆÚ“® //@}
+//	aptr<T>& operator=( aptr<T>& r )
+//		{
+//			if( obj_ != r.obj_ )
+//			{
+//				delete obj_;
+//				obj_ = r.release();
+//			}
+//			return *this;
+//		}
 
-	//@{ Š—LŒ ˆÚ“® //@}
-	aptr<T>& operator=( aptr<T>& r )
+	void reset( T *r )
 		{
-			if( obj_ != r.obj_ )
-			{
-				delete obj_;
-				obj_ = r.release();
-			}
-			return *this;
+			delete obj_;
+			obj_ = r;
 		}
+
+//	void move( aptr<T>& r )
+//		{
+//			delete obj_;
+//			obj_ = r.release();
+//		}
 
 public:
 
@@ -78,7 +90,7 @@ public:
 		}
 
 private:
-
+	NOCOPY(aptr);
 	mutable T* obj_;
 };
 

--- a/kilib/ktlaptr.h
+++ b/kilib/ktlaptr.h
@@ -2,8 +2,8 @@
 #define _KILIB_KTL_APTR_H_
 #include "types.h"
 #ifdef _MSC_VER
-//#pragma warning( disable : 4284 ) // 警告：->のリターン型がうにゃうにゃ
-//#pragma warning( disable : 4150 ) // 警告：deleteの定義がうにょうにょ
+#pragma warning( disable : 4284 ) // 警告：->のリターン型がうにゃうにゃ
+#pragma warning( disable : 4150 ) // 警告：deleteの定義がうにょうにょ
 #endif
 #ifndef __ccdoc__
 namespace ki {
@@ -16,7 +16,7 @@ namespace ki {
 //@{
 //	自動ポインタ
 //
-//	私の期待する範囲では概ね std::auto_ptr と同じ動作をすると思う…。
+//	私の期待する範囲では概ね std::unique_ptr と同じ動作をすると思う…。
 //	車輪の最発明ばんざーい！
 //@}
 //=========================================================================

--- a/kilib/ktlaptr.h
+++ b/kilib/ktlaptr.h
@@ -2,8 +2,8 @@
 #define _KILIB_KTL_APTR_H_
 #include "types.h"
 #ifdef _MSC_VER
-#pragma warning( disable : 4284 ) // 警告：->のリターン型がうにゃうにゃ
-#pragma warning( disable : 4150 ) // 警告：deleteの定義がうにょうにょ
+//#pragma warning( disable : 4284 ) // 警告：->のリターン型がうにゃうにゃ
+//#pragma warning( disable : 4150 ) // 警告：deleteの定義がうにょうにょ
 #endif
 #ifndef __ccdoc__
 namespace ki {
@@ -34,7 +34,7 @@ public:
 	~uptr()
 		{ delete obj_; }
 
-	//@{ Set/Reset object, (delete the old) //@} 
+	//@{ Set/Reset object, (delete the old) //@}
 	void reset( T *ptr = NULL )
 		{
 		#ifdef _DEBUG
@@ -44,12 +44,6 @@ public:
 			T *old = obj_;
 			obj_ = ptr;
 			delete old;
-		}
-
-	//@{ Transfer ownership of r to here //@} 
-	void move( uptr& r )
-		{
-			reset( r.release() );
 		}
 
 public:

--- a/kilib/ktlaptr.h
+++ b/kilib/ktlaptr.h
@@ -76,7 +76,7 @@ public:
 
 private:
 	NOCOPY(uptr);
-	mutable T* obj_;
+	T* obj_;
 };
 
 
@@ -143,7 +143,7 @@ public:
 
 private:
 
-	mutable T* obj_;
+	T* obj_;
 };
 
 


### PR DESCRIPTION
rename aptr to uptr as a ref to unique pointer.
we can use .release() instead of std::move().
Add the reset method to change the object pointed to.
remove the copy operations. (`NOCOPY(uptr)`;)

use reset where possible, avoids the creation of an intermediate aptr.
