### PR TITLE
Open selection as a file with F7

### DIFF
--- a/GpMain.h
+++ b/GpMain.h
@@ -115,6 +115,7 @@ private:
 	void    on_drop( HDROP hd );
 	void    on_move( const editwing::DPos& c, const editwing::DPos& s ) override;
 	void    on_jump();
+	void    on_openselection();
 	void    on_grep();
 	void    on_help();
 	void    on_external_exe_start(const ki::Path& g);

--- a/rsrc/gp_rsrc.rc
+++ b/rsrc/gp_rsrc.rc
@@ -141,7 +141,7 @@ BEGIN
         MENUITEM "I&nvert Case\tAlt+I",         ID_CMD_INVERTCASE
         MENUITEM "Tri&m Trailing Spaces\tAlt+W",ID_CMD_TTSPACES
         MENUITEM "Strip &First Characters\tAlt+Z",ID_CMD_SFCHAR
-        MENUITEM "Strip &Last Characters\tAlt+A",ID_CMD_SFCHAR
+        MENUITEM "Strip &Last Characters\tAlt+A",ID_CMD_SLCHAR
         MENUITEM "&Quote\tAlt+Q",               ID_CMD_QUOTE
         MENUITEM "Unqu&ote\tAlt+N",             ID_CMD_UNQUOTE
       # ifndef NO_IME
@@ -159,6 +159,7 @@ BEGIN
         MENUITEM "指定行へジャンプ(&J)\tCtrl+J", ID_CMD_JUMP
         MENUITEM SEPARATOR
         MENUITEM "Grep(&G)...\tCtrl+G",         ID_CMD_GREP
+        MENUITEM "&Open Selection...\tF7",      ID_CMD_OPENSELECTION
     END
     POPUP "表示(&V)"
     BEGIN
@@ -433,6 +434,7 @@ BEGIN
     "F",            ID_CMD_FIND,            VIRTKEY, CONTROL, NOINVERT
     "G",            ID_CMD_GREP,            VIRTKEY, CONTROL, NOINVERT
     VK_F1,          ID_CMD_HELP,            VIRTKEY, NOINVERT
+    VK_F7,          ID_CMD_OPENSELECTION,   VIRTKEY, NOINVERT
     "H",            ID_CMD_FIND,            VIRTKEY, CONTROL, NOINVERT
     "J",            ID_CMD_JUMP,            VIRTKEY, CONTROL, NOINVERT
     "N",            ID_CMD_NEWFILE,         VIRTKEY, CONTROL, NOINVERT
@@ -541,7 +543,7 @@ BEGIN
         MENUITEM "I&nvert Case\tAlt+I",         ID_CMD_INVERTCASE
         MENUITEM "Tri&m Trailing Spaces\tAlt+W",ID_CMD_TTSPACES
         MENUITEM "Strip &First Characters\tAlt+Z",ID_CMD_SFCHAR
-        MENUITEM "Strip &Last Characters\tAlt+A",ID_CMD_SFCHAR
+        MENUITEM "Strip &Last Characters\tAlt+A",ID_CMD_SLCHAR
         MENUITEM "&Quote\tAlt+Q",               ID_CMD_QUOTE
         MENUITEM "Unqu&ote\tAlt+N",             ID_CMD_UNQUOTE
 
@@ -561,6 +563,7 @@ BEGIN
         MENUITEM "&Jump to Line\tCtrl+J",       ID_CMD_JUMP
         MENUITEM SEPARATOR
         MENUITEM "&Grep...\tCtrl+G",            ID_CMD_GREP
+        MENUITEM "&Open Selection...\tF7",      ID_CMD_OPENSELECTION
     END
     POPUP "&View"
     BEGIN

--- a/rsrc/resource.h
+++ b/rsrc/resource.h
@@ -135,6 +135,7 @@
 #define ID_CMD_DELENDFILE               50014
 #define ID_CMD_DELSTAFILE               50015
 #define ID_CMD_HELP                     50016
+#define ID_CMD_OPENSELECTION            50017
 
 // Next default values for new objects
 //


### PR DESCRIPTION
Add the on_openselection() function to open the current selection as a relative or absolute path in GreenPad.

Minor various fixes:
* Gray out all edit stuff when no selection is available.
* Fix StripLastCharacter menu entry.