### PR TITLE
Fix detection of cp_acp compatible string

### DIFF
--- a/kilib/kstring.h
+++ b/kilib/kstring.h
@@ -281,6 +281,9 @@ public:
 	//@{ ConvTo(W)Charの返値バッファの解放 //@}
 	void FreeWCMem( const wchar_t* wc ) const;
 	void FreeCMem( const char* str ) const;
+	
+	static bool isCompatibleWithACP(const TCHAR *uni, size_t len);
+	bool isCompatibleWithACP() const;
 
 public:
 
@@ -458,6 +461,9 @@ inline void String::FreeCMem( const char* str ) const
 #else // _MBCS or _SBCS
 	{}
 #endif
+
+inline bool String::isCompatibleWithACP() const
+{ return isCompatibleWithACP( c_str(), len() ); }
 
 
 

--- a/kilib/registry.cpp
+++ b/kilib/registry.cpp
@@ -183,9 +183,7 @@ bool IniFile::PutRect( const TCHAR* key, const RECT *rc  )
 bool IniFile::PutPath( const TCHAR* key, const Path& val )
 {
 #ifdef _UNICODE
-	BOOL err = FALSE;
-	::WideCharToMultiByte( CP_ACP, 0, val.c_str(), -1, NULL, 0, NULL, &err );
-	if( !err )
+	if( val.isCompatibleWithACP() )
 		return PutStr( key , val.c_str() );
 
 	// UTF-encoder

--- a/kilib/registry.cpp
+++ b/kilib/registry.cpp
@@ -191,7 +191,7 @@ bool IniFile::PutPath( const TCHAR* key, const Path& val )
 		'0','1','2','3','4','5','6','7',
 		'8','9','a','b','c','d','e','f' };
 	String buf = TEXT("#");
-	for(unsigned i=0; i!=val.len(); ++i)
+	for(size_t i=0; i<val.len(); ++i)
 	{
 		unsigned short u = (unsigned short) val[i];
 		if( u > 127 || u == L'%' )

--- a/kilib/string.cpp
+++ b/kilib/string.cpp
@@ -498,7 +498,7 @@ bool String::isCompatibleWithACP(const TCHAR *uni, size_t len)
 		return true;
 
 	BOOL err = FALSE;
-	int mblen = ::WideCharToMultiByte( CP_ACP, 0, uni, len+1, NULL, 0, NULL, &err );
+	int mblen = ::WideCharToMultiByte( CP_ACP, 0, uni, len, NULL, 0, NULL, &err );
 
 	if( err || !mblen )
 	{	// String is incompatible with CP_ACP for sure.
@@ -511,15 +511,15 @@ bool String::isCompatibleWithACP(const TCHAR *uni, size_t len)
 
 	char *mbbuf = new char[mblen];
 	if( !mbbuf ) return false;
-	mblen = ::WideCharToMultiByte( CP_ACP, 0, uni, len+1, mbbuf, mblen, NULL, NULL );
+	mblen = ::WideCharToMultiByte( CP_ACP, 0, uni, len, mbbuf, mblen, NULL, NULL );
 	if( !mblen ) return false;
 
-	wchar_t *backconv = new wchar_t[len+1];
+	wchar_t *backconv = new wchar_t[len];
 	if( !backconv ) return false;
-	size_t backconvlen = ::MultiByteToWideChar(CP_ACP, 0, mbbuf, mblen, backconv, len+1);
+	size_t backconvlen = ::MultiByteToWideChar(CP_ACP, 0, mbbuf, mblen, backconv, len);
 	delete [] mbbuf;
 
-	if( backconvlen != len || my_lstrcmpW( uni, backconv ) )
+	if( backconvlen != len || my_lstrncmpW( uni, backconv, len ) )
 		compatible = false; // Not matching
 	delete [] backconv;
 

--- a/kilib/string.cpp
+++ b/kilib/string.cpp
@@ -498,7 +498,7 @@ bool String::isCompatibleWithACP(const TCHAR *uni, size_t len)
 		return true;
 
 	BOOL err = FALSE;
-	int mblen = ::WideCharToMultiByte( CP_ACP, 0, uni, len, NULL, 0, NULL, &err );
+	int mblen = ::WideCharToMultiByte( CP_ACP, 0, uni, len+1, NULL, 0, NULL, &err );
 
 	if( err || !mblen )
 	{	// String is incompatible with CP_ACP for sure.
@@ -508,22 +508,24 @@ bool String::isCompatibleWithACP(const TCHAR *uni, size_t len)
 	// Because WC_NO_BEST_FIT_CHARS requires Windows 2000/XP
 	// Some losses are thus invisible to the err flag!
 	bool compatible = true;
+
 	char *mbbuf = new char[mblen];
 	if( !mbbuf ) return false;
-	mblen = ::WideCharToMultiByte( CP_ACP, 0, uni, len, mbbuf, mblen, NULL, NULL );
+	mblen = ::WideCharToMultiByte( CP_ACP, 0, uni, len+1, mbbuf, mblen, NULL, NULL );
 	if( !mblen ) return false;
 
-	TCHAR *backconv = new TCHAR[len];
+	wchar_t *backconv = new wchar_t[len+1];
 	if( !backconv ) return false;
-	size_t backconvlen = ::MultiByteToWideChar(CP_ACP, 0, mbbuf, mblen, backconv, len);
-	if( backconvlen != len || my_lstrcmpW( uni, backconv ) )
-		compatible = false; // not matching
-	delete [] backconv;
+	size_t backconvlen = ::MultiByteToWideChar(CP_ACP, 0, mbbuf, mblen, backconv, len+1);
 	delete [] mbbuf;
+
+	if( backconvlen != len || my_lstrcmpW( uni, backconv ) )
+		compatible = false; // Not matching
+	delete [] backconv;
 
 	return compatible;
 #else
-	return true; // TCHAR == char so it is always OK.
+	return true;
 #endif
 }
 

--- a/kilib/string.cpp
+++ b/kilib/string.cpp
@@ -388,7 +388,7 @@ String& String::operator = ( const wchar_t* s )
 
 String& String::Load( UINT rsrcID )
 {
-	const int step=256;
+	enum { step=256 };
 
 	// 256バイトの固定長バッファへまず読んでみる
 	TCHAR tmp[step], *buf;
@@ -488,6 +488,42 @@ const char* String::ConvToChar() const
 	return p;
 #else
 	return c_str();
+#endif
+}
+
+bool String::isCompatibleWithACP(const TCHAR *uni, size_t len)
+{
+#ifdef _UNICODE
+	if( len ==0 )
+		return true;
+
+	BOOL err = FALSE;
+	int mblen = ::WideCharToMultiByte( CP_ACP, 0, uni, len, NULL, 0, NULL, &err );
+
+	if( err || !mblen )
+	{	// String is incompatible with CP_ACP for sure.
+		return false;
+	}
+	// Double check that we get the same unicode string when converting back.
+	// Because WC_NO_BEST_FIT_CHARS requires Windows 2000/XP
+	// Some losses are thus invisible to the err flag!
+	bool compatible = true;
+	char *mbbuf = new char[mblen];
+	if( !mbbuf ) return false;
+	mblen = ::WideCharToMultiByte( CP_ACP, 0, uni, len, mbbuf, mblen, NULL, NULL );
+	if( !mblen ) return false;
+
+	TCHAR *backconv = new TCHAR[len];
+	if( !backconv ) return false;
+	size_t backconvlen = ::MultiByteToWideChar(CP_ACP, 0, mbbuf, mblen, backconv, len);
+	if( backconvlen != len || my_lstrcmpW( uni, backconv ) )
+		compatible = false; // not matching
+	delete [] backconv;
+	delete [] mbbuf;
+
+	return compatible;
+#else
+	return true; // TCHAR == char so it is always OK.
 #endif
 }
 


### PR DESCRIPTION
Add the isCompatibleWithACP() function in the String class.
To do this we need to convert from Unicode to local CP_ACP and then back to Unicode to finally compare the original string with the final string and if they are equal then we can be sure.

The reason we need to do that is because WC2MB silently converts some latin characters to their undecorated equivalent. This induce losses.

eg: if you use CP1252 the character `ħ` gets converted to `h` without warning.
On Windows 2000+ we could use the `WC_NO_BEST_FIT_CHARS` flag..