### PR TITLE
Do not reparse lines before file is fully loaded

### DIFF
--- a/editwing/ip_doc.h
+++ b/editwing/ip_doc.h
@@ -457,7 +457,7 @@ private:
 
 	// ‘}“üEíœì‹Æ
 	bool InsertingOperation(
-		DPos& stt, const unicode* str, ulong len, DPos& undoend );
+		DPos& stt, const unicode* str, ulong len, DPos& undoend, bool reparse=true );
 	bool DeletingOperation(
 		DPos& stt, DPos& end, unicode*& undobuf, ulong& undosiz );
 

--- a/editwing/ip_text.cpp
+++ b/editwing/ip_text.cpp
@@ -564,7 +564,7 @@ bool Document::DeletingOperation
 }
 
 bool Document::InsertingOperation
-	( DPos& s, const unicode* str, ulong len, DPos& e )
+	( DPos& s, const unicode* str, ulong len, DPos& e, bool reparse )
 {
 	AutoLock lk( this );
 
@@ -613,9 +613,8 @@ bool Document::InsertingOperation
 	}
 
 	// çƒâêÕ, Reanalysis
-	return ReParse( s.tl, e.tl );
+	return reparse && ReParse( s.tl, e.tl );
 }
-
 
 
 //-------------------------------------------------------------------------
@@ -815,19 +814,6 @@ void Document::OpenFile( TextFileR& tf )
 	// ë}ì¸, Insertion
 	DPos e(0,0);
 
-//	// Quick UTF16 special direct reading.
-//	if( tf.codepage() == UTF16LE ||  tf.codepage() == UTF16l )
-//	{
-//		DPos p(0,0);
-//		//DWORD otime = GetTickCount();
-//		const unicode *buf = reinterpret_cast<const unicode*>( tf.rawData() );
-//		int bom = *buf == 0xfffe; // Skip BOM
-//		InsertingOperation(p , buf+bom, (tf.size()/2)-bom, e );
-//		Fire_TEXTUPDATE( DPos(0,0), DPos(0,0), e, true, false );
-//		//MessageBox(GetForegroundWindow(),  SInt2Str(GetTickCount()-otime).c_str(), TEXT("Time in ms UTF16:"), 0);
-//		return; // DONE!
-//	}
-
 	// Super small stack buffer in case the malloc fails
 	#define SBUF_SZ 1800
 	unicode sbuf[SBUF_SZ];
@@ -853,12 +839,15 @@ void Document::OpenFile( TextFileR& tf )
 	}
 //	DWORD otime = GetTickCount();
 	size_t L;
-	for( ulong i=0; L = tf.ReadBuf( buf, buf_sz ); )
+	ulong i=0;
+	for( i=0; L = tf.ReadBuf( buf, buf_sz ); )
 	{
-		DPos p(i,0xffffffff);
-		InsertingOperation( p, buf, (ulong)L, e );
+		DPos p( i, len(e.tl) ); // end of document
+		InsertingOperation( p, buf, (ulong)L, e, /*reparse=*/false );
 		i = tln() - 1;
 	}
+	// Parse All lines, because we skipped it
+	ReParse( 0, tln()-1 );
 
 	if( buf != sbuf )
 		delete [] buf;

--- a/editwing/ip_text.cpp
+++ b/editwing/ip_text.cpp
@@ -839,8 +839,7 @@ void Document::OpenFile( TextFileR& tf )
 	}
 //	DWORD otime = GetTickCount();
 	size_t L;
-	ulong i=0;
-	for( i=0; L = tf.ReadBuf( buf, buf_sz ); )
+	for( ulong i=0; L = tf.ReadBuf( buf, buf_sz ); )
 	{
 		DPos p( i, len(e.tl) ); // end of document
 		InsertingOperation( p, buf, (ulong)L, e, /*reparse=*/false );


### PR DESCRIPTION
This improves performances by a significant margin, because it means that we do not reparse many times the same line over and over again when the line is much larger than the intermediate buf used in `Document::OpenFile( )`

For now on my machine I went from 6sec->1sec to load a file with a single 16MB line.
And for a 64MB line I went from almost 2 minutes down to 3 sec.